### PR TITLE
Fix bad requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build:
+          context: circleci-user
   build_daily:
     triggers:
       - schedule:
@@ -45,4 +46,5 @@ workflows:
               only:
                 - master
     jobs:
-      - build
+      - build:
+          context: circleci-user

--- a/tap_linkedin_ads/schema.py
+++ b/tap_linkedin_ads/schema.py
@@ -73,6 +73,13 @@ def get_schemas():
             valid_replication_keys=stream_metadata.get('replication_keys', None),
             replication_method=stream_metadata.get('replication_method', None)
         )
+
+        # Add additional metadata
+        if stream_name in ('ad_analytics_by_campaign', 'ad_analytics_by_creative'):
+            mdata_map = metadata.to_map(mdata)
+            mdata_map[('properties', 'date_range')]['inclusion'] = 'automatic'
+            mdata = metadata.to_list(mdata_map)
+
         field_metadata[stream_name] = mdata
 
     return schemas, field_metadata

--- a/tap_linkedin_ads/schemas/account_users.json
+++ b/tap_linkedin_ads/schemas/account_users.json
@@ -1,55 +1,91 @@
 {
-	"type": "object",
-	"additionalProperties": false,
-	"properties": {
-		"account": {
-			"type": ["null", "string"]
-		},
-		"account_id": {
-			"type": ["null", "integer"]
-		},
-		"change_audit_stamps": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"created": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				},
-				"last_modified": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				}
-			}
-		},
-		"created_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"last_modified_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"role": {
-			"type": ["null", "string"]
-		},
-		"user": {
-			"type": ["null", "string"]
-		},
-		"user_person_id": {
-			"type": ["null", "string"]
-		}
-	}
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    },
+    "created_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "role": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "user": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "user_person_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
 }

--- a/tap_linkedin_ads/schemas/accounts.json
+++ b/tap_linkedin_ads/schemas/accounts.json
@@ -1,114 +1,190 @@
 {
-	"type": "object",
-	"additionalProperties": false,
-	"properties": {
-		"change_audit_stamps": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"created": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				},
-				"last_modified": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				}
-			}
-		},
-		"created_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"last_modified_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"currency": {
-			"type": ["null", "string"]
-		},
-		"id": {
-			"type": ["null", "integer"]
-		},
-		"name": {
-			"type": ["null", "string"]
-		},
-		"notified_on_campaign_optimization": {
-			"type": ["null", "boolean"]
-		},
-		"notified_on_creative_approval": {
-			"type": ["null", "boolean"]
-		},
-		"notified_on_creative_rejection": {
-			"type": ["null", "boolean"]
-		},
-		"notified_on_end_of_campaign": {
-			"type": ["null", "boolean"]
-		},
-		"reference": {
-			"type": ["null", "string"]
-		},
-		"reference_organization_id": {
-			"type": ["null", "integer"]
-		},
-		"reference_person_id": {
-			"type": ["null", "string"]
-		},
-		"serving_statuses": {
-			"anyOf": [{
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"status": {
-			"type": ["null", "string"]
-		},
-		"total_budget": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"amount": {
-					"type": ["null", "number"],
-					"multipleOf": 1e-08
-				},
-				"currency_code": {
-					"type": ["null", "string"]
-				}
-			}
-		},
-		"total_budget_ends_at": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"type": {
-			"type": ["null", "string"]
-		},
-		"version": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"version_tag": {
-					"type": ["null", "string"]
-				}
-			}
-		}
-	}
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    },
+    "created_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "notified_on_campaign_optimization": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "notified_on_creative_approval": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "notified_on_creative_rejection": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "notified_on_end_of_campaign": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "reference": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reference_organization_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "reference_person_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "serving_statuses": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "total_budget": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "number"
+          ],
+          "multipleOf": 1e-08
+        },
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "total_budget_ends_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "version": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "version_tag": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    }
+  }
 }

--- a/tap_linkedin_ads/schemas/ad_analytics_by_campaign.json
+++ b/tap_linkedin_ads/schemas/ad_analytics_by_campaign.json
@@ -1,266 +1,501 @@
 {
-	"type": "object",
-	"additionalProperties": false,
-        "properties": {
-                "approximate_unique_impressions": {
-                        "type": ["null", "integer"]
-                },
-                "card_clicks": {
-                        "type": ["null", "integer"]
-                },
-                "card_impressions": {
-                        "type": ["null", "integer"]
-                },
-                "comment_likes": {
-                        "type": ["null", "integer"]
-                },
-                "viral_card_clicks": {
-                        "type": ["null", "integer"]
-                },
-                "viral_card_impressions": {
-                        "type": ["null", "integer"]
-                },
-                "viral_comment_likes": {
-                        "type": ["null", "integer"]
-                },
-		"campaign": {
-			"type": ["null", "string"]
-		},
-		"campaign_id": {
-			"type": ["null", "integer"]
-		},
-		"start_at": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"end_at": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"action_clicks": {
-			"type": ["null", "integer"]
-		},
-		"ad_unit_clicks": {
-			"type": ["null", "integer"]
-		},
-		"clicks": {
-			"type": ["null", "integer"]
-		},
-		"comments": {
-			"type": ["null", "integer"]
-		},
-		"company_page_clicks": {
-			"type": ["null", "integer"]
-		},
-		"conversion_value_in_local_currency": {
-			"type": ["null", "number"],
-			"multipleOf": 1e-08
-		},
-		"cost_in_local_currency": {
-			"type": ["null", "number"],
-			"multipleOf": 1e-08
-		},
-		"cost_in_usd": {
-			"type": ["null", "number"],
-			"multipleOf": 1e-08
-		},
-		"date_range": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"end": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"day": {
-							"type": ["null", "integer"]
-						},
-						"month": {
-							"type": ["null", "integer"]
-						},
-						"year": {
-							"type": ["null", "integer"]
-						}
-					}
-				},
-				"start": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"day": {
-							"type": ["null", "integer"]
-						},
-						"month": {
-							"type": ["null", "integer"]
-						},
-						"year": {
-							"type": ["null", "integer"]
-						}
-					}
-				}
-			}
-		},
-		"external_website_conversions": {
-			"type": ["null", "integer"]
-		},
-		"external_website_post_click_conversions": {
-			"type": ["null", "integer"]
-		},
-		"external_website_post_view_conversions": {
-			"type": ["null", "integer"]
-		},
-		"follows": {
-			"type": ["null", "integer"]
-		},
-		"full_screen_plays": {
-			"type": ["null", "integer"]
-		},
-		"impressions": {
-			"type": ["null", "integer"]
-		},
-		"landing_page_clicks": {
-			"type": ["null", "integer"]
-		},
-		"lead_generation_mail_contact_info_shares": {
-			"type": ["null", "integer"]
-		},
-		"lead_generation_mail_interest_clicks": {
-			"type": ["null", "integer"]
-		},
-		"likes": {
-			"type": ["null", "integer"]
-		},
-		"one_click_lead_form_opens": {
-			"type": ["null", "integer"]
-		},
-		"one_click_leads": {
-			"type": ["null", "integer"]
-		},
-		"opens": {
-			"type": ["null", "integer"]
-		},
-		"other_engagements": {
-			"type": ["null", "integer"]
-		},
-		"pivot": {
-			"type": ["null", "string"]
-		},
-		"pivot_value": {
-			"type": ["null", "string"]
-		},
-		"pivot_values": {
-			"anyOf": [{
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"reactions": {
-			"type": ["null", "integer"]
-		},
-		"sends": {
-			"type": ["null", "integer"]
-		},
-		"shares": {
-			"type": ["null", "integer"]
-		},
-		"text_url_clicks": {
-			"type": ["null", "integer"]
-		},
-		"total_engagements": {
-			"type": ["null", "integer"]
-		},
-		"video_completions": {
-			"type": ["null", "integer"]
-		},
-		"video_first_quartile_completions": {
-			"type": ["null", "integer"]
-		},
-		"video_midpoint_completions": {
-			"type": ["null", "integer"]
-		},
-		"video_starts": {
-			"type": ["null", "integer"]
-		},
-		"video_third_quartile_completions": {
-			"type": ["null", "integer"]
-		},
-		"video_views": {
-			"type": ["null", "integer"]
-		},
-		"viral_clicks": {
-			"type": ["null", "integer"]
-		},
-		"viral_comments": {
-			"type": ["null", "integer"]
-		},
-		"viral_company_page_clicks": {
-			"type": ["null", "integer"]
-		},
-		"viral_external_website_conversions": {
-			"type": ["null", "integer"]
-		},
-		"viral_external_website_post_click_conversions": {
-			"type": ["null", "integer"]
-		},
-		"viral_external_website_post_view_conversions": {
-			"type": ["null", "integer"]
-		},
-		"viral_follows": {
-			"type": ["null", "integer"]
-		},
-		"viral_full_screen_plays": {
-			"type": ["null", "integer"]
-		},
-		"viral_impressions": {
-			"type": ["null", "integer"]
-		},
-		"viral_landing_page_clicks": {
-			"type": ["null", "integer"]
-		},
-		"viral_likes": {
-			"type": ["null", "integer"]
-		},
-		"viral_one_click_lead_form_opens": {
-			"type": ["null", "integer"]
-		},
-		"viral_one_click_leads": {
-			"type": ["null", "integer"]
-		},
-		"viral_other_engagements": {
-			"type": ["null", "integer"]
-		},
-		"viral_reactions": {
-			"type": ["null", "integer"]
-		},
-		"viral_shares": {
-			"type": ["null", "integer"]
-		},
-		"viral_total_engagements": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_completions": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_first_quartile_completions": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_midpoint_completions": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_starts": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_third_quartile_completions": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_views": {
-			"type": ["null", "integer"]
-		}
-	}
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "approximate_unique_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "card_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "card_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "comment_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_card_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_card_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_comment_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "campaign": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "start_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "end_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "action_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "ad_unit_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "comments": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "company_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "conversion_value_in_local_currency": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "multipleOf": 1e-08
+    },
+    "cost_in_local_cy": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "multipleOf": 1e-08
+    },
+    "cost_in_usd": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "multipleOf": 1e-08
+    },
+    "date_range": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "end": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "day": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "month": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "year": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        },
+        "start": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "day": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "month": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "year": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "external_website_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "external_website_post_click_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "external_website_post_view_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "follows": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "full_screen_plays": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "landing_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "lead_generation_mail_contact_info_shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "lead_generation_mail_interest_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "one_click_lead_form_opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "one_click_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "other_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "pivot": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pivot_value": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pivot_values": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "reactions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "sends": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "text_url_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "total_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_starts": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_views": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_comments": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_company_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_post_click_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_post_view_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_follows": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_full_screen_plays": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_landing_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_one_click_lead_form_opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_one_click_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_other_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_reactions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_total_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_starts": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_views": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    }
+  }
 }

--- a/tap_linkedin_ads/schemas/ad_analytics_by_campaign.json
+++ b/tap_linkedin_ads/schemas/ad_analytics_by_campaign.json
@@ -1,7 +1,28 @@
 {
 	"type": "object",
 	"additionalProperties": false,
-	"properties": {
+        "properties": {
+                "approximate_unique_impressions": {
+                        "type": ["null", "integer"]
+                },
+                "card_clicks": {
+                        "type": ["null", "integer"]
+                },
+                "card_impressions": {
+                        "type": ["null", "integer"]
+                },
+                "comment_likes": {
+                        "type": ["null", "integer"]
+                },
+                "viral_card_clicks": {
+                        "type": ["null", "integer"]
+                },
+                "viral_card_impressions": {
+                        "type": ["null", "integer"]
+                },
+                "viral_comment_likes": {
+                        "type": ["null", "integer"]
+                },
 		"campaign": {
 			"type": ["null", "string"]
 		},

--- a/tap_linkedin_ads/schemas/ad_analytics_by_creative.json
+++ b/tap_linkedin_ads/schemas/ad_analytics_by_creative.json
@@ -1,7 +1,28 @@
 {
 	"type": "object",
 	"additionalProperties": false,
-	"properties": {
+        "properties": {
+                "approximate_unique_impressions": {
+                        "type": ["null", "integer"]
+                },
+                "card_clicks": {
+                        "type": ["null", "integer"]
+                },
+                "card_impressions": {
+                        "type": ["null", "integer"]
+                },
+                "comment_likes": {
+                        "type": ["null", "integer"]
+                },
+                "viral_card_clicks": {
+                        "type": ["null", "integer"]
+                },
+                "viral_card_impressions": {
+                        "type": ["null", "integer"]
+                },
+                "viral_comment_likes": {
+                        "type": ["null", "integer"]
+                },
 		"creative": {
 			"type": ["null", "string"]
 		},

--- a/tap_linkedin_ads/schemas/ad_analytics_by_creative.json
+++ b/tap_linkedin_ads/schemas/ad_analytics_by_creative.json
@@ -1,266 +1,501 @@
 {
-	"type": "object",
-	"additionalProperties": false,
-        "properties": {
-                "approximate_unique_impressions": {
-                        "type": ["null", "integer"]
-                },
-                "card_clicks": {
-                        "type": ["null", "integer"]
-                },
-                "card_impressions": {
-                        "type": ["null", "integer"]
-                },
-                "comment_likes": {
-                        "type": ["null", "integer"]
-                },
-                "viral_card_clicks": {
-                        "type": ["null", "integer"]
-                },
-                "viral_card_impressions": {
-                        "type": ["null", "integer"]
-                },
-                "viral_comment_likes": {
-                        "type": ["null", "integer"]
-                },
-		"creative": {
-			"type": ["null", "string"]
-		},
-		"creative_id": {
-			"type": ["null", "integer"]
-		},
-		"start_at": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"end_at": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"action_clicks": {
-			"type": ["null", "integer"]
-		},
-		"ad_unit_clicks": {
-			"type": ["null", "integer"]
-		},
-		"clicks": {
-			"type": ["null", "integer"]
-		},
-		"comments": {
-			"type": ["null", "integer"]
-		},
-		"company_page_clicks": {
-			"type": ["null", "integer"]
-		},
-		"conversion_value_in_local_currency": {
-			"type": ["null", "number"],
-			"multipleOf": 1e-08
-		},
-		"cost_in_local_currency": {
-			"type": ["null", "number"],
-			"multipleOf": 1e-08
-		},
-		"cost_in_usd": {
-			"type": ["null", "number"],
-			"multipleOf": 1e-08
-		},
-		"date_range": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"end": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"day": {
-							"type": ["null", "integer"]
-						},
-						"month": {
-							"type": ["null", "integer"]
-						},
-						"year": {
-							"type": ["null", "integer"]
-						}
-					}
-				},
-				"start": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"day": {
-							"type": ["null", "integer"]
-						},
-						"month": {
-							"type": ["null", "integer"]
-						},
-						"year": {
-							"type": ["null", "integer"]
-						}
-					}
-				}
-			}
-		},
-		"external_website_conversions": {
-			"type": ["null", "integer"]
-		},
-		"external_website_post_click_conversions": {
-			"type": ["null", "integer"]
-		},
-		"external_website_post_view_conversions": {
-			"type": ["null", "integer"]
-		},
-		"follows": {
-			"type": ["null", "integer"]
-		},
-		"full_screen_plays": {
-			"type": ["null", "integer"]
-		},
-		"impressions": {
-			"type": ["null", "integer"]
-		},
-		"landing_page_clicks": {
-			"type": ["null", "integer"]
-		},
-		"lead_generation_mail_contact_info_shares": {
-			"type": ["null", "integer"]
-		},
-		"lead_generation_mail_interest_clicks": {
-			"type": ["null", "integer"]
-		},
-		"likes": {
-			"type": ["null", "integer"]
-		},
-		"one_click_lead_form_opens": {
-			"type": ["null", "integer"]
-		},
-		"one_click_leads": {
-			"type": ["null", "integer"]
-		},
-		"opens": {
-			"type": ["null", "integer"]
-		},
-		"other_engagements": {
-			"type": ["null", "integer"]
-		},
-		"pivot": {
-			"type": ["null", "string"]
-		},
-		"pivot_value": {
-			"type": ["null", "string"]
-		},
-		"pivot_values": {
-			"anyOf": [{
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"reactions": {
-			"type": ["null", "integer"]
-		},
-		"sends": {
-			"type": ["null", "integer"]
-		},
-		"shares": {
-			"type": ["null", "integer"]
-		},
-		"text_url_clicks": {
-			"type": ["null", "integer"]
-		},
-		"total_engagements": {
-			"type": ["null", "integer"]
-		},
-		"video_completions": {
-			"type": ["null", "integer"]
-		},
-		"video_first_quartile_completions": {
-			"type": ["null", "integer"]
-		},
-		"video_midpoint_completions": {
-			"type": ["null", "integer"]
-		},
-		"video_starts": {
-			"type": ["null", "integer"]
-		},
-		"video_third_quartile_completions": {
-			"type": ["null", "integer"]
-		},
-		"video_views": {
-			"type": ["null", "integer"]
-		},
-		"viral_clicks": {
-			"type": ["null", "integer"]
-		},
-		"viral_comments": {
-			"type": ["null", "integer"]
-		},
-		"viral_company_page_clicks": {
-			"type": ["null", "integer"]
-		},
-		"viral_external_website_conversions": {
-			"type": ["null", "integer"]
-		},
-		"viral_external_website_post_click_conversions": {
-			"type": ["null", "integer"]
-		},
-		"viral_external_website_post_view_conversions": {
-			"type": ["null", "integer"]
-		},
-		"viral_follows": {
-			"type": ["null", "integer"]
-		},
-		"viral_full_screen_plays": {
-			"type": ["null", "integer"]
-		},
-		"viral_impressions": {
-			"type": ["null", "integer"]
-		},
-		"viral_landing_page_clicks": {
-			"type": ["null", "integer"]
-		},
-		"viral_likes": {
-			"type": ["null", "integer"]
-		},
-		"viral_one_click_lead_form_opens": {
-			"type": ["null", "integer"]
-		},
-		"viral_one_click_leads": {
-			"type": ["null", "integer"]
-		},
-		"viral_other_engagements": {
-			"type": ["null", "integer"]
-		},
-		"viral_reactions": {
-			"type": ["null", "integer"]
-		},
-		"viral_shares": {
-			"type": ["null", "integer"]
-		},
-		"viral_total_engagements": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_completions": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_first_quartile_completions": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_midpoint_completions": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_starts": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_third_quartile_completions": {
-			"type": ["null", "integer"]
-		},
-		"viral_video_views": {
-			"type": ["null", "integer"]
-		}
-	}
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "approximate_unique_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "card_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "card_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "comment_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_card_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_card_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_comment_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "creative": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "creative_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "start_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "end_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "action_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "ad_unit_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "comments": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "company_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "conversion_value_in_local_currency": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "multipleOf": 1e-08
+    },
+    "cost_in_local_currency": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "multipleOf": 1e-08
+    },
+    "cost_in_usd": {
+      "type": [
+        "null",
+        "number"
+      ],
+      "multipleOf": 1e-08
+    },
+    "date_range": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "end": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "day": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "month": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "year": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        },
+        "start": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "day": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "month": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "year": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "external_website_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "external_website_post_click_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "external_website_post_view_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "follows": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "full_screen_plays": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "landing_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "lead_generation_mail_contact_info_shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "lead_generation_mail_interest_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "one_click_lead_form_opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "one_click_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "other_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "pivot": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pivot_value": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pivot_values": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "reactions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "sends": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "text_url_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "total_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_starts": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_views": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_comments": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_company_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_post_click_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_post_view_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_follows": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_full_screen_plays": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_landing_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_one_click_lead_form_opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_one_click_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_other_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_reactions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_total_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_starts": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_views": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    }
+  }
 }

--- a/tap_linkedin_ads/schemas/campaign_groups.json
+++ b/tap_linkedin_ads/schemas/campaign_groups.json
@@ -1,84 +1,133 @@
 {
-	"type": "object",
-	"additionalProperties": false,
-	"properties": {
-		"run_schedule": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"start": {
-					"type": ["null", "string"],
-					"format": "date-time"
-				},
-				"end": {
-					"type": ["null", "string"],
-					"format": "date-time"
-				}
-			}
-		},
-		"change_audit_stamps": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"created": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				},
-				"last_modified": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				}
-			}
-		},
-		"created_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"last_modified_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"name": {
-			"type": ["null", "string"]
-		},
-		"serving_statuses": {
-			"anyOf": [{
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"backfilled": {
-			"type": ["null", "boolean"]
-		},
-		"id": {
-			"type": ["null", "integer"]
-		},
-		"account": {
-			"type": ["null", "string"]
-		},
-		"account_id": {
-			"type": ["null", "integer"]
-		},
-		"status": {
-			"type": ["null", "string"]
-		}
-	}
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "run_schedule": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "end": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    },
+    "created_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "serving_statuses": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "backfilled": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "account": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
 }

--- a/tap_linkedin_ads/schemas/campaigns.json
+++ b/tap_linkedin_ads/schemas/campaigns.json
@@ -108,37 +108,71 @@
 						}
 					}
 				},
-				"exclude": {
-					"anyOf": [{
-							"type": "array",
-							"items": {
-								"type": "object",
-								"additionalProperties": false,
-								"properties": {
-									"type": {
-										"type": ["null", "string"]
-									},
-									"values": {
-										"anyOf": [{
-												"type": "array",
-												"items": {
-													"type": "string"
-												}
-											},
-											{
-												"type": "null"
-											}
-										]
-									}
-								}
-							}
-						},
-						{
-							"type": "null"
-						}
-					]
-				}
-			}
+                    "exclude": {
+                      "type": [
+                        "null",
+                        "object"
+                      ],
+                      "properties": {
+                        "or": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "urn:li:ad_targeting_facet:titles": {
+                              "type": [
+                                "null",
+                                "array"
+                              ],
+                              "items": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            },
+                            "urn:li:ad_targeting_facet:staff_count_ranges": {
+                              "type": [
+                                "null",
+                                "array"
+                              ],
+                              "items": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            },
+                            "urn:li:ad_targeting_facet:followed_companies": {
+                              "type": [
+                                "null",
+                                "array"
+                              ],
+                              "items": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            },
+                            "urn:li:ad_targeting_facet:seniorities": {
+                              "type": [
+                                "null",
+                                "array"
+                              ],
+                              "items": {
+                                "type": [
+                                  "null",
+                                  "string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+		  }
 		},
 		"serving_statuses": {
 			"anyOf": [{

--- a/tap_linkedin_ads/schemas/campaigns.json
+++ b/tap_linkedin_ads/schemas/campaigns.json
@@ -1,333 +1,469 @@
 {
-	"type": "object",
-	"additionalProperties": false,
-	"properties": {
-		"targeting": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"included_targeting_facets": {
-					"anyOf": [{
-							"type": "array",
-							"items": {
-								"type": "object",
-								"additionalProperties": false,
-								"properties": {
-									"type": {
-										"type": ["null", "string"]
-									},
-									"values": {
-										"anyOf": [{
-												"type": "array",
-												"items": {
-													"type": "string"
-												}
-											},
-											{
-												"type": "null"
-											}
-										]
-									}
-								}
-							}
-						},
-						{
-							"type": "null"
-						}
-					]
-				},
-				"excluded_targeting_facets": {
-					"anyOf": [{
-							"type": "array",
-							"items": {
-								"type": "object",
-								"additionalProperties": false,
-								"properties": {
-									"type": {
-										"type": ["null", "string"]
-									},
-									"values": {
-										"anyOf": [{
-												"type": "array",
-												"items": {
-													"type": "string"
-												}
-											},
-											{
-												"type": "null"
-											}
-										]
-									}
-								}
-							}
-						},
-						{
-							"type": "null"
-						}
-					]
-				}
-			}
-		},
-		"targeting_criteria": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"include": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"and": {
-							"anyOf": [{
-									"type": "array",
-									"items": {
-										"type": "object",
-										"additionalProperties": false,
-										"properties": {
-											"type": {
-												"type": ["null", "string"]
-											},
-											"values": {
-												"anyOf": [{
-														"type": "array",
-														"items": {
-															"type": "string"
-														}
-													},
-													{
-														"type": "null"
-													}
-												]
-											}
-										}
-									}
-								},
-								{
-									"type": "null"
-								}
-							]
-						}
-					}
-				},
-                    "exclude": {
-                      "type": [
-                        "null",
-                        "object"
-                      ],
-                      "properties": {
-                        "or": {
-                          "type": [
-                            "null",
-                            "object"
-                          ],
-                          "properties": {
-                            "urn:li:ad_targeting_facet:titles": {
-                              "type": [
-                                "null",
-                                "array"
-                              ],
-                              "items": {
-                                "type": [
-                                  "null",
-                                  "string"
-                                ]
-                              }
-                            },
-                            "urn:li:ad_targeting_facet:staff_count_ranges": {
-                              "type": [
-                                "null",
-                                "array"
-                              ],
-                              "items": {
-                                "type": [
-                                  "null",
-                                  "string"
-                                ]
-                              }
-                            },
-                            "urn:li:ad_targeting_facet:followed_companies": {
-                              "type": [
-                                "null",
-                                "array"
-                              ],
-                              "items": {
-                                "type": [
-                                  "null",
-                                  "string"
-                                ]
-                              }
-                            },
-                            "urn:li:ad_targeting_facet:seniorities": {
-                              "type": [
-                                "null",
-                                "array"
-                              ],
-                              "items": {
-                                "type": [
-                                  "null",
-                                  "string"
-                                ]
-                              }
-                            }
-                          }
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "targeting": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "included_targeting_facets": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "values": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
                         }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "excluded_targeting_facets": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "values": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "targeting_criteria": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "include": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "and": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "values": {
+                        "anyOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     }
-		  }
-		},
-		"serving_statuses": {
-			"anyOf": [{
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"type": {
-			"type": ["null", "string"]
-		},
-		"locale": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"country": {
-					"type": ["null", "string"]
-				},
-				"language": {
-					"type": ["null", "string"]
-				}
-			}
-		},
-		"version": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"version_tag": {
-					"type": ["null", "string"]
-				}
-			}
-		},
-		"associated_entity": {
-			"type": ["null", "string"]
-		},
-		"associated_entity_organization_id": {
-			"type": ["null", "integer"]
-		},
-		"associated_entity_person_id": {
-			"type": ["null", "string"]
-		},
-		"run_schedule": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"start": {
-					"type": ["null", "string"],
-					"format": "date-time"
-				},
-				"end": {
-					"type": ["null", "string"],
-					"format": "date-time"
-				}
-			}
-		},
-		"optimization_target_type": {
-			"type": ["null", "string"]
-		},
-		"change_audit_stamps": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"created": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				},
-				"last_modified": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				}
-			}
-		},
-		"created_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"last_modified_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"campaign_group": {
-			"type": ["null", "string"]
-		},
-		"campaign_group_id": {
-			"type": ["null", "integer"]
-		},
-		"daily_budget": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"amount": {
-					"type": ["null", "number"],
-					"multipleOf": 1e-08
-				},
-				"currency_code": {
-					"type": ["null", "string"]
-				}
-			}
-		},
-		"unit_cost": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"amount": {
-					"type": ["null", "number"],
-					"multipleOf": 1e-08
-				},
-				"currency_code": {
-					"type": ["null", "string"]
-				}
-			}
-		},
-		"creative_selection": {
-			"type": ["null", "string"]
-		},
-		"cost_type": {
-			"type": ["null", "string"]
-		},
-		"name": {
-			"type": ["null", "string"]
-		},
-		"offsite_delivery_enabled": {
-			"type": ["null", "boolean"]
-		},
-		"id": {
-			"type": ["null", "integer"]
-		},
-		"audience_expansion_enabled": {
-			"type": ["null", "boolean"]
-		},
-		"account": {
-			"type": ["null", "string"]
-		},
-		"account_id": {
-			"type": ["null", "integer"]
-		},
-		"status": {
-			"type": ["null", "string"]
-		}
-	}
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "exclude": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "or": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "urn:li:ad_targeting_facet:titles": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "urn:li:ad_targeting_facet:staff_count_ranges": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "urn:li:ad_targeting_facet:followed_companies": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "urn:li:ad_targeting_facet:seniorities": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "serving_statuses": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "locale": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "language": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "version": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "version_tag": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "associated_entity": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "associated_entity_organization_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "associated_entity_person_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "run_schedule": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "end": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
+    "optimization_target_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    },
+    "created_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "campaign_group": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_group_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "daily_budget": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "number"
+          ],
+          "multipleOf": 1e-08
+        },
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "unit_cost": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "number"
+          ],
+          "multipleOf": 1e-08
+        },
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "creative_selection": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cost_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "offsite_delivery_enabled": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "audience_expansion_enabled": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "account": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
 }

--- a/tap_linkedin_ads/schemas/creatives.json
+++ b/tap_linkedin_ads/schemas/creatives.json
@@ -1,112 +1,182 @@
 {
-	"type": "object",
-	"additionalProperties": false,
-	"properties": {
-		"campaign": {
-			"type": ["null", "string"]
-		},
-		"campaign_id": {
-			"type": ["null", "integer"]
-		},
-		"change_audit_stamps": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"created": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				},
-				"last_modified": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				}
-			}
-		},
-		"created_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"last_modified_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"id": {
-			"type": ["null", "integer"]
-		},
-		"reference": {
-			"type": ["null", "string"]
-		},
-		"reference_share_id": {
-			"type": ["null", "integer"]
-		},
-		"review": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"review_status": {
-					"type": ["null", "string"]
-				}
-			}
-		},
-		"status": {
-			"type": ["null", "string"]
-		},
-		"type": {
-			"type": ["null", "string"]
-		},
-		"variables": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"click_uri": {
-					"type": ["null", "string"]
-				},
-				"type": {
-					"type": ["null", "string"]
-				},
-				"values": {
-					"anyOf": [{
-							"type": "array",
-							"items": {
-								"type": "object",
-								"additionalProperties": false,
-								"properties": {
-									"key": {
-										"type": ["null", "string"]
-									},
-									"value": {
-										"type": ["null", "string"]
-									}
-								}
-							}
-						},
-						{
-							"type": "null"
-						}
-					]
-				}
-			}
-		},
-		"version": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"version_tag": {
-					"type": ["null", "string"]
-				}
-			}
-		}
-	}
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "campaign": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    },
+    "created_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "reference": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reference_share_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "review": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "review_status": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "variables": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "click_uri": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "values": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "version": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "version_tag": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    }
+  }
 }

--- a/tap_linkedin_ads/schemas/video_ads.json
+++ b/tap_linkedin_ads/schemas/video_ads.json
@@ -1,67 +1,115 @@
 {
-	"type": "object",
-	"additionalProperties": false,
-	"properties": {
-		"account": {
-			"type": ["null", "string"]
-		},
-		"account_id": {
-			"type": ["null", "integer"]
-		},
-		"change_audit_stamps": {
-			"type": ["null", "object"],
-			"additionalProperties": false,
-			"properties": {
-				"created": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				},
-				"last_modified": {
-					"type": ["null", "object"],
-					"additionalProperties": false,
-					"properties": {
-						"time": {
-							"type": ["null", "string"],
-							"format": "date-time"
-						}
-					}
-				}
-			}
-		},
-		"created_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"last_modified_time": {
-			"type": ["null", "string"],
-			"format": "date-time"
-		},
-		"content_reference": {
-			"type": ["null", "string"]
-		},
-		"content_reference_ucg_post_id": {
-			"type": ["null", "integer"]
-		},
-		"content_reference_share_id": {
-			"type": ["null", "integer"]
-		},
-		"name": {
-			"type": ["null", "string"]
-		},
-		"owner": {
-			"type": ["null", "string"]
-		},
-		"owner_organization_id": {
-			"type": ["null", "integer"]
-		},
-		"type": {
-			"type": ["null", "string"]
-		}
-	}
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    },
+    "created_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "content_reference": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_reference_ucg_post_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "content_reference_share_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "owner": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "owner_organization_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
 }

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -509,7 +509,8 @@ def sync(client, config, catalog, state):
                     },
                     'data_key': 'elements',
                     'bookmark_field': 'end_at',
-                    'id_fields': ['creative_id', 'start_at']
+                    'id_fields': ['creative_id', 'start_at'],
+                    'parent': 'campaign',
                 },
                 'creatives': {
                     'path': 'adCreativesV2',
@@ -541,7 +542,8 @@ def sync(client, config, catalog, state):
                     },
                     'data_key': 'elements',
                     'bookmark_field': 'end_at',
-                    'id_fields': ['creative_id', 'start_at']
+                    'id_fields': ['creative_id', 'start_at'],
+                    'parent': 'creative',
                 }
             }
         }

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -511,7 +511,6 @@ def sync(client, config, catalog, state):
                     },
                     'data_key': 'elements',
                     'bookmark_field': 'end_at',
-                    'id_fields': ['creative_id', 'start_at'],
                     'parent': 'campaign',
                 },
                 'creatives': {

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -544,8 +544,7 @@ def sync(client, config, catalog, state):
                     },
                     'data_key': 'elements',
                     'bookmark_field': 'end_at',
-                    'id_fields': ['creative_id', 'start_at'],
-                    'parent': 'creative',
+                    'id_fields': ['creative_id', 'start_at']
                 }
             }
         }

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -1,7 +1,7 @@
 import urllib.parse
 from datetime import timedelta
 import singer
-from singer import metrics, metadata, Transformer, utils, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
+from singer import metrics, metadata, Transformer, utils, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING, should_sync_field
 from singer.utils import strptime_to_utc, strftime
 from tap_linkedin_ads.transform import transform_json
 
@@ -518,3 +518,15 @@ def sync(client, config, catalog, state):
                         stream_name,
                         total_records)
             LOGGER.info('FINISHED Syncing: %s', stream_name)
+
+def selected_fields(catalog_for_stream):
+    mdata = metadata.to_map(catalog_for_stream.metadata)
+    fields = catalog_for_stream.schema.properties.keys()
+
+    selected_fields_list = list()
+    for field in fields:
+        field_metadata = mdata.get(('properties', field))
+        if should_sync_field(field_metadata.get('inclusion'), field_metadata.get('selected')):
+            selected_fields_list.append(field)
+
+    return selected_fields_list

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -35,6 +35,8 @@ FIELDS_AVAILABLE_FOR_AD_ANALYTICS_V2 = {
     'oneClickLeads',
     'opens',
     'otherEngagements',
+    'pivot',
+    'pivotValue',
     'pivotValues',
     'reactions',
     'sends',

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -292,6 +292,10 @@ def sync_endpoint(client, #pylint: disable=too-many-branches,too-many-statements
                                                          for field in selected_fields(catalog.get_stream(child_stream_name))
                                                          if snake_case_to_camel_case(field) in FIELDS_AVAILABLE_FOR_AD_ANALYTICS_V2]
 
+                                field_count = len(valid_selected_fields)
+                                if field_count > 20:
+                                    raise RuntimeError("LinkedIn's API limits the field count for {} to 20 metrics (You have selected {}).".format(child_stream_name, field_count))
+
                                 child_endpoint_config['params']['fields'] = ','.join(valid_selected_fields)
 
                         LOGGER.info('Syncing: %s, parent_stream: %s, parent_id: %s',

--- a/tap_linkedin_ads/transform.py
+++ b/tap_linkedin_ads/transform.py
@@ -13,6 +13,15 @@ def convert(name):
     regsub = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', regsub).lower()
 
+def snake_case_to_camel_case(text):
+    if not text:
+        return text
+
+    words = text.split('_')
+    first_word = words[0]
+    remaining_words = words[1:]
+
+    return first_word + ''.join(word.title() for word in remaining_words)
 
 # Convert keys in json array
 def convert_array(arr):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -38,7 +38,7 @@ class LinkedinAdsSyncTest(unittest.TestCase):
         return self.ALL_STREAMS
 
     def expected_sync_streams(self):
-        return self.ALL_STREAMS
+        return self.ALL_STREAMS - {'ad_analytics_by_creative'}
 
     def expected_pks(self):
         return {
@@ -147,17 +147,18 @@ class LinkedinAdsSyncTest(unittest.TestCase):
         # Select all streams and all fields
         for entry in catalog_entries:
 
-            schema = menagerie.select_catalog(conn_id, entry)
+            if entry.get('tap_stream_id') in self.expected_sync_streams():
+                schema = menagerie.select_catalog(conn_id, entry)
 
-            catalog_entry = {
-                'key_properties': entry.get('key_properties'),
-                'schema' : schema,
-                'tap_stream_id': entry.get('tap_stream_id'),
-                'replication_method': entry.get('replication_method'),
-                'replication_key': entry.get('replication_key')
-            }
+                catalog_entry = {
+                    'key_properties': entry.get('key_properties'),
+                    'schema' : schema,
+                    'tap_stream_id': entry.get('tap_stream_id'),
+                    'replication_method': entry.get('replication_method'),
+                    'replication_key': entry.get('replication_key')
+                }
 
-            connections.select_catalog_and_fields_via_metadata(conn_id, catalog_entry, schema)
+                connections.select_catalog_and_fields_via_metadata(conn_id, catalog_entry, schema)
 
         # found_catalogs = menagerie.get_catalogs(conn_id)
         self.assertGreater(len(catalog_entries),


### PR DESCRIPTION
# Description of change
- Limits the max fields selected for ads_analytics_by_campaign to 20, which is the new max implemented by linkedin
- Adds the fields param to the request
- Updates schema issues


# Manual QA steps
 - Ran the tap, confirmed it does work for <= 20 fields

# Risks
 - low, mainly changes code that was already broken by the 20 metrics limit
 
# Rollback steps
 - revert this branch
