### PR TITLE
Add date windowing

### DIFF
--- a/tap_linkedin_ads/schema.py
+++ b/tap_linkedin_ads/schema.py
@@ -78,6 +78,8 @@ def get_schemas():
         if stream_name in ('ad_analytics_by_campaign', 'ad_analytics_by_creative'):
             mdata_map = metadata.to_map(mdata)
             mdata_map[('properties', 'date_range')]['inclusion'] = 'automatic'
+            mdata_map[('properties', 'pivot')]['inclusion'] = 'automatic'
+            mdata_map[('properties', 'pivot_value')]['inclusion'] = 'automatic'
             mdata = metadata.to_list(mdata_map)
 
         field_metadata[stream_name] = mdata

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -309,21 +309,41 @@ def sync_endpoint(client, #pylint: disable=too-many-branches,too-many-statements
                                     stream_name,
                                     parent_id)
                         child_path = child_endpoint_config.get('path')
-                        child_total_records, child_batch_bookmark_value = sync_endpoint(
-                            client=client,
-                            catalog=catalog,
-                            state=state,
-                            start_date=start_date,
-                            stream_name=child_stream_name,
-                            path=child_path,
-                            endpoint_config=child_endpoint_config,
-                            data_key=child_endpoint_config.get('data_key', 'elements'),
-                            static_params=child_endpoint_config.get('params', {}),
-                            bookmark_query_field=child_endpoint_config.get('bookmark_query_field'),
-                            bookmark_field=child_endpoint_config.get('bookmark_field'),
-                            id_fields=child_endpoint_config.get('id_fields'),
-                            parent=child_endpoint_config.get('parent'),
-                            parent_id=parent_id)
+
+                        if child_stream_name == 'ad_analytics_by_campaign':
+                            child_total_records, child_batch_bookmark_value = sync_ad_analytics(
+                                client=client,
+                                catalog=catalog,
+                                state=state,
+                                start_date=last_datetime,
+                                stream_name=child_stream_name,
+                                path=child_path,
+                                endpoint_config=child_endpoint_config,
+                                data_key=child_endpoint_config.get('data_key', 'elements'),
+                                static_params=child_endpoint_config.get('params', {}),
+                                bookmark_query_field=child_endpoint_config.get('bookmark_query_field'),
+                                bookmark_field=child_endpoint_config.get('bookmark_field'),
+                                id_fields=child_endpoint_config.get('id_fields'),
+                                parent=child_endpoint_config.get('parent'),
+                                parent_id=parent_id)
+
+                        else:
+
+                            child_total_records, child_batch_bookmark_value = sync_endpoint(
+                                client=client,
+                                catalog=catalog,
+                                state=state,
+                                start_date=start_date,
+                                stream_name=child_stream_name,
+                                path=child_path,
+                                endpoint_config=child_endpoint_config,
+                                data_key=child_endpoint_config.get('data_key', 'elements'),
+                                static_params=child_endpoint_config.get('params', {}),
+                                bookmark_query_field=child_endpoint_config.get('bookmark_query_field'),
+                                bookmark_field=child_endpoint_config.get('bookmark_field'),
+                                id_fields=child_endpoint_config.get('id_fields'),
+                                parent=child_endpoint_config.get('parent'),
+                                parent_id=parent_id)
 
                         child_batch_bookmark_dttm = strptime_to_utc(child_batch_bookmark_value)
                         child_max_bookmark = child_max_bookmarks.get(child_stream_name)

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -1,9 +1,9 @@
 import urllib.parse
 import datetime
 from datetime import timedelta
-import pytz
 import singer
-from singer import metrics, metadata, Transformer, utils, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING, should_sync_field
+from singer import metrics, metadata, utils
+from singer import Transformer, should_sync_field, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
 from singer.utils import strptime_to_utc, strftime
 from tap_linkedin_ads.transform import transform_json, snake_case_to_camel_case
 
@@ -15,11 +15,11 @@ DATE_WINDOW_SIZE = 30 # days
 FIELDS_AVAILABLE_FOR_AD_ANALYTICS_V2 = {
     'actionClicks',
     'adUnitClicks',
-    'approximateUniqueImpressions', #Add
-    'cardClicks', #Add
-    'cardImpressions', #Add
+    'approximateUniqueImpressions',
+    'cardClicks',
+    'cardImpressions',
     'clicks',
-    'commentLikes', #Add
+    'commentLikes',
     'comments',
     'companyPageClicks',
     'conversionValueInLocalCurrency',
@@ -118,8 +118,8 @@ def write_bookmark(state, stream, value):
     LOGGER.info('Write state for stream: %s, value: %s', stream, value)
     singer.write_state(state)
 
-
-def process_records(catalog, #pylint: disable=too-many-branches
+# pylint: disable=too-many-arguments,too-many-locals
+def process_records(catalog,
                     stream_name,
                     records,
                     time_extracted,
@@ -148,8 +148,7 @@ def process_records(catalog, #pylint: disable=too-many-branches
 
                 # Reset max_bookmark_value to new value if higher
                 if bookmark_field and (bookmark_field in transformed_record):
-                    if max_bookmark_value is None or \
-                        strptime_to_utc(transformed_record[bookmark_field]) > strptime_to_utc(max_bookmark_value):
+                    if max_bookmark_value is None or strptime_to_utc(transformed_record[bookmark_field]) > strptime_to_utc(max_bookmark_value):
                         max_bookmark_value = transformed_record[bookmark_field]
 
                 if bookmark_field and (bookmark_field in transformed_record):
@@ -167,7 +166,8 @@ def process_records(catalog, #pylint: disable=too-many-branches
 
 
 # Sync a specific parent or child endpoint.
-def sync_endpoint(client, #pylint: disable=too-many-branches,too-many-statements
+# pylint: disable=too-many-branches,too-many-statements,too-many-arguments,too-many-locals
+def sync_endpoint(client,
                   catalog,
                   state,
                   start_date,
@@ -294,16 +294,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches,too-many-statements
                                 child_endpoint_config['params']['search.campaign.values[0]'] = campaign
                             elif child_stream_name in ('ad_analytics_by_campaign', 'ad_analytics_by_creative'):
                                 child_endpoint_config['params']['campaigns[0]'] = campaign
-                                # get selected fields
-                                valid_selected_fields = [snake_case_to_camel_case(field)
-                                                         for field in selected_fields(catalog.get_stream(child_stream_name))
-                                                         if snake_case_to_camel_case(field) in FIELDS_AVAILABLE_FOR_AD_ANALYTICS_V2]
-
-                                field_count = len(valid_selected_fields)
-                                if field_count > 20:
-                                    raise RuntimeError("LinkedIn's API limits the field count for {} to 20 metrics (You have selected {}).".format(child_stream_name, field_count))
-
-                                child_endpoint_config['params']['fields'] = ','.join(valid_selected_fields)
 
                         LOGGER.info('Syncing: %s, parent_stream: %s, parent_id: %s',
                                     child_stream_name,
@@ -316,7 +306,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches,too-many-statements
                                 client=client,
                                 catalog=catalog,
                                 state=state,
-                                start_date=last_datetime,
+                                last_datetime=last_datetime,
                                 stream_name=child_stream_name,
                                 path=child_path,
                                 endpoint_config=child_endpoint_config,
@@ -646,25 +636,57 @@ def selected_fields(catalog_for_stream):
 
     return selected_fields_list
 
-def sync_ad_analytics(client,
-                      catalog,
-                      state,
-                      start_date,
-                      stream_name,
-                      path,
-                      endpoint_config,
-                      data_key,
-                      static_params,
-                      bookmark_query_field=None,
-                      bookmark_field=None,
-                      id_fields=None,
-                      parent=None,
-                      parent_id=None):
+def split_into_chunks(fields, chunk_length):
+    return (fields[x:x+chunk_length] for x in range(0, len(fields), chunk_length))
+
+def shift_sync_window(params, today, forced_window_size=None):
+    current_end = datetime.date(
+        year=params['dateRange.end.year'],
+        month=params['dateRange.end.month'],
+        day=params['dateRange.end.day'],
+    )
+    if forced_window_size:
+        new_end = current_end + timedelta(days=forced_window_size)
+    else:
+        new_end = current_end + timedelta(days=DATE_WINDOW_SIZE)
+
+    if new_end > today:
+        new_end = today
+
+    new_params = {**params,
+                  'dateRange.start.day': current_end.day,
+                  'dateRange.start.month': current_end.month,
+                  'dateRange.start.year': current_end.year,
+
+                  'dateRange.end.day': new_end.day,
+                  'dateRange.end.month': new_end.month,
+                  'dateRange.end.year': new_end.year,}
+    return current_end, new_end, new_params
+
+def merge_responses(data):
+    full_records = dict()
+    for page in data:
+        for element in page:
+            temp_start = element['dateRange']['start']
+            string_start = '{}-{}-{}'.format(temp_start['year'], temp_start['month'], temp_start['day'])
+            if string_start in full_records:
+                full_records[string_start].update(element)
+            else:
+                full_records[string_start] = element
+    return full_records
+
+
+def sync_ad_analytics(client, catalog, state, last_datetime, stream_name, path, endpoint_config, data_key, static_params,
+                      bookmark_query_field=None, bookmark_field=None, id_fields=None, parent=None, parent_id=None):
     # pylint: disable=too-many-branches,too-many-statements,unused-argument
 
-    # start_date here is not the config's start date, it's the bookmark
-    # value, which can fall back to the config's start date
-    last_datetime_dt = strptime_to_utc(start_date) - timedelta(days=7)
+    # LinkedIn has a max of 20 fields per request. We cap the chunks at 17
+    # to make sure there's always room for us to append `dateRange`,
+    # `pivot`, and `pivotValue`
+    MAX_CHUNK_LENGTH = 17
+
+    max_bookmark_value = last_datetime
+    last_datetime_dt = strptime_to_utc(last_datetime) - timedelta(days=7)
 
     window_start_date = last_datetime_dt.date()
     window_end_date = window_start_date + timedelta(days=DATE_WINDOW_SIZE)
@@ -683,56 +705,101 @@ def sync_ad_analytics(client,
                      'dateRange.end.month': window_end_date.month,
                      'dateRange.end.year': window_end_date.year,}
 
+    valid_selected_fields = [snake_case_to_camel_case(field)
+                             for field in selected_fields(catalog.get_stream(stream_name))
+                             if snake_case_to_camel_case(field) in FIELDS_AVAILABLE_FOR_AD_ANALYTICS_V2]
+
+    # When testing the API, if the fields in `field` all return `0` then
+    # the API returns its empty response.
+
+    # However, the API distinguishes between a day with non-null values
+    # (even if this means the values are all `0`) and a day with null
+    # values. We found that requesting these fields give you the days with
+    # non-null values
+    first_chunk = [['dateRange', 'pivot', 'pivotValue']]
+
+    chunks = first_chunk + list(split_into_chunks(valid_selected_fields, MAX_CHUNK_LENGTH))
+
+    # We have to append these fields in order to ensure we get them back
+    # so that we can create the composite primary key for the record and
+    # to merge the multiple responses based on this primary key
+    for chunk in chunks:
+        for field in ['dateRange', 'pivot', 'pivotValue']:
+            if field not in chunk:
+                chunk.append(field)
+
     total_records = 0
     while window_end_date <= today:
-        window_total_records, _ = sync_endpoint(
-            client=client,
-            catalog=catalog,
-            state=state,
-            start_date=start_date,
-            stream_name=stream_name,
-            path=endpoint_config.get('path'),
-            endpoint_config=endpoint_config,
-            data_key=endpoint_config.get('data_key', 'elements'),
-            static_params=static_params,
-            bookmark_query_field=endpoint_config.get('bookmark_query_field'),
-            bookmark_field=endpoint_config.get('bookmark_field'),
-            id_fields=endpoint_config.get('id_fields'),
-            parent=endpoint_config.get('parent'),
-            parent_id=parent_id)
+        responses = []
+        for chunk in chunks:
+            static_params['fields'] = ','.join(chunk)
+            params = {"start": 0,
+                      "count": endpoint_config.get('count', 100),
+                      **static_params}
+            query_string = '&'.join(['%s=%s' % (key, value) for (key, value) in params.items()])
+            LOGGER.info('Syncing %s from %s to %s', parent_id, window_start_date, window_end_date)
+            for page in sync_analytics_endpoint(client, stream_name, endpoint_config.get('path'), query_string):
+                if page.get(data_key):
+                    responses.append(page.get(data_key))
+        raw_records = merge_responses(responses)
+        time_extracted = utils.now()
 
-        total_records += window_total_records
+        # While we broke the ad_analytics streams out from
+        # `sync_endpoint()`, we want to process them the same. And
+        # transform_json() expects a dictionary with a key equal to
+        # `data_key` and its value is the response from the API
 
-        # WE have to convert the window_end (date object) into a datetime
-        # in order to singer.strftime() it for the bookmark
-        bookmark_value = datetime.datetime(
-            year=window_end_date.year,
-            month=window_end_date.month,
-            day=window_end_date.day,
-            hour=0,
-            minute=0,
-            second=0,
-            tzinfo=pytz.UTC
-        )
+        # Note that `transform_json()` returns the same structure we pass
+        # in. `sync_endpoint()` grabs `data_key` from the return value, so
+        # we mirror that here
+        transformed_data = transform_json({data_key: list(raw_records.values())},
+                                          stream_name)[data_key]
+        if not transformed_data:
+            LOGGER.info('No transformed_data')
+        else:
+            max_bookmark_value, record_count = process_records(
+                catalog=catalog,
+                stream_name=stream_name,
+                records=transformed_data,
+                time_extracted=time_extracted,
+                bookmark_field=bookmark_field,
+                max_bookmark_value=last_datetime,
+                last_datetime=strftime(last_datetime_dt),
+                parent=parent,
+                parent_id=parent_id)
+            LOGGER.info('%s, records processed: %s', stream_name, record_count)
+            LOGGER.info('%s: max_bookmark: %s', stream_name, max_bookmark_value)
+            total_records += record_count
 
-        max_bookmark = strftime(bookmark_value)
+        window_start_date, window_end_date, static_params = shift_sync_window(static_params, today)
 
-        window_start_date = window_end_date
-        window_end_date = window_start_date + timedelta(days=DATE_WINDOW_SIZE)
+        if window_start_date == window_end_date:
+            break
 
-        if window_end_date > today:
-            window_end_date = today
+    return total_records, max_bookmark_value
 
-            if window_start_date == window_end_date:
-                break
+def sync_analytics_endpoint(client, stream_name, path, query_string):
+    page = 1
+    next_url = 'https://api.linkedin.com/v2/{}?{}'.format(path, query_string)
 
-        static_params = {**static_params,
-                         'dateRange.start.day': window_start_date.day,
-                         'dateRange.start.month': window_start_date.month,
-                         'dateRange.start.year': window_start_date.year,
+    while next_url:
+        LOGGER.info('URL for %s: %s', stream_name, next_url)
 
-                         'dateRange.end.day': window_end_date.day,
-                         'dateRange.end.month': window_end_date.month,
-                         'dateRange.end.year': window_end_date.year,}
+        data = client.get(url=next_url, endpoint=stream_name)
+        yield data
+        next_url = get_next_url(data)
 
-    return total_records, max_bookmark
+        LOGGER.info('%s: Synced page %s', stream_name, page)
+        page = page + 1
+
+
+def get_next_url(data):
+    next_url = None
+    links = data.get('paging', {}).get('links', [])
+    for link in links:
+        rel = link.get('rel')
+        if rel == 'next':
+            href = link.get('href')
+            if href:
+                next_url = 'https://api.linkedin.com{}'.format(urllib.parse.unquote(href))
+    return next_url

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -186,7 +186,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches,too-many-statements
     max_bookmark_value = last_datetime
     LOGGER.info('%s: bookmark last_datetime = %s', stream_name, max_bookmark_value)
 
-    write_schema(catalog, stream_name)
 
     # Initialize child_max_bookmarks
     child_max_bookmarks = {}
@@ -198,6 +197,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches,too-many-statements
                                                   child_stream_name)
 
             if should_stream:
+                write_schema(catalog, child_stream_name)
                 child_bookmark_field = child_endpoint_config.get('bookmark_field')
                 if child_bookmark_field:
                     child_last_datetime = get_bookmark(state, stream_name, start_date)
@@ -598,6 +598,10 @@ def sync(client, config, catalog, state):
             update_currently_syncing(state, stream_name)
             path = endpoint_config.get('path')
             bookmark_field = endpoint_config.get('bookmark_field')
+
+            # Write schema for parent streams
+            write_schema(catalog, stream_name)
+
             total_records, max_bookmark_value = sync_endpoint(
                 client=client,
                 catalog=catalog,

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -424,7 +424,7 @@ def sync(client, config, catalog, state):
 
     if config.get('date_window_size'):
         LOGGER.info('Using non-standard date window size of %s', config.get('date_window_size'))
-        global DATE_WINDOW_SIZE
+        global DATE_WINDOW_SIZE # pylint: disable=global-statement
         DATE_WINDOW_SIZE = config.get('date_window_size')
     else:
         LOGGER.info('Using standard date window size of %s', DATE_WINDOW_SIZE)
@@ -646,7 +646,7 @@ def selected_fields(catalog_for_stream):
 
     return selected_fields_list
 
-def sync_ad_analytics(client, #pylint: disable=too-many-branches,too-many-statements
+def sync_ad_analytics(client,
                       catalog,
                       state,
                       start_date,
@@ -660,6 +660,7 @@ def sync_ad_analytics(client, #pylint: disable=too-many-branches,too-many-statem
                       id_fields=None,
                       parent=None,
                       parent_id=None):
+    # pylint: disable=too-many-branches,too-many-statements,unused-argument
     # Maybe use start_date here instead of last_datetime?
     last_datetime_dt = strptime_to_utc(start_date) - timedelta(days=7)
 

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -661,7 +661,9 @@ def sync_ad_analytics(client,
                       parent=None,
                       parent_id=None):
     # pylint: disable=too-many-branches,too-many-statements,unused-argument
-    # Maybe use start_date here instead of last_datetime?
+
+    # start_date here is not the config's start date, it's the bookmark
+    # value, which can fall back to the config's start date
     last_datetime_dt = strptime_to_utc(start_date) - timedelta(days=7)
 
     window_start_date = last_datetime_dt.date()

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -422,6 +422,13 @@ def sync(client, config, catalog, state):
     if 'start_date' in config:
         start_date = config['start_date']
 
+    if config.get('date_window_size'):
+        LOGGER.info('Using non-standard date window size of %s', config.get('date_window_size'))
+        global DATE_WINDOW_SIZE
+        DATE_WINDOW_SIZE = config.get('date_window_size')
+    else:
+        LOGGER.info('Using standard date window size of %s', DATE_WINDOW_SIZE)
+
     # Get datetimes for endpoint parameters
     now = utils.now()
     # delta = 7 days to account for delays in ads data
@@ -657,7 +664,7 @@ def sync_ad_analytics(client, #pylint: disable=too-many-branches,too-many-statem
     last_datetime_dt = strptime_to_utc(start_date) - timedelta(days=7)
 
     window_start_date = last_datetime_dt.date()
-    window_end_date = window_start_date + timedelta(days=DATE_WINDOW_SIZE) # maybe make this configurable
+    window_end_date = window_start_date + timedelta(days=DATE_WINDOW_SIZE)
     today = datetime.date.today()
 
     if window_end_date > today:

--- a/tap_linkedin_ads/transform.py
+++ b/tap_linkedin_ads/transform.py
@@ -88,7 +88,7 @@ def transform_analytics(data_dict):
         val = data_dict['pivot_value']
         search = re.search('^urn:li:(.*):(.*)$', val)
         if search:
-            data_dict['{}'.format(key)] = val
+            data_dict[key] = val
     # Create start_at and end_at fields from nested date_range
     if 'date_range' in data_dict:
         if 'start' in data_dict['date_range']:

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,197 @@
+import datetime
+import unittest
+from tap_linkedin_ads.sync import DATE_WINDOW_SIZE
+from tap_linkedin_ads.sync import get_next_url
+from tap_linkedin_ads.sync import merge_responses
+from tap_linkedin_ads.sync import shift_sync_window
+from tap_linkedin_ads.sync import split_into_chunks
+
+
+
+class TestSyncUtils(unittest.TestCase):
+    def test_split_into_chunks(self):
+        MAX_CHUNK_LENGTH = 17
+        fields = list(range(65))
+
+        actual = split_into_chunks(fields, MAX_CHUNK_LENGTH)
+
+        expected = [
+            [ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16],
+            [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33],
+            [34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50],
+            [51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64]
+        ]
+
+        self.assertEqual(expected, list(actual))
+
+    def test_split_into_chunks_2(self):
+        MAX_CHUNK_LENGTH = 17
+        fields = list(range(25))
+
+        actual = split_into_chunks(fields, MAX_CHUNK_LENGTH)
+
+        expected = [
+            [ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16],
+            [17, 18, 19, 20, 21, 22, 23, 24],
+        ]
+
+        self.assertEqual(expected, list(actual))
+
+    def test_get_next_url(self):
+        data = {
+            'paging': {
+                'links': []
+            }
+        }
+
+        links = [{'rel': 'next', 'href': '/foo'},]
+
+        expected_1 = None
+        actual_1 = get_next_url(data)
+
+        self.assertEqual(expected_1, actual_1)
+
+        data['paging']['links'] = links
+        expected_2 = 'https://api.linkedin.com/foo'
+        actual_2 = get_next_url(data)
+
+        self.assertEqual(expected_2, actual_2)
+
+    def test_shift_sync_window_non_boundary(self):
+        expected_start_date = datetime.date(year=2020, month=10, day=1)
+        expected_end_date = datetime.date(year=2020, month=10, day=31)
+        expected_params = {
+            'dateRange.start.year': expected_start_date.year,
+            'dateRange.start.month': expected_start_date.month,
+            'dateRange.start.day': expected_start_date.day,
+            'dateRange.end.year': expected_end_date.year,
+            'dateRange.end.month': expected_end_date.month,
+            'dateRange.end.day': expected_end_date.day,
+        }
+
+        params = {
+            'dateRange.end.year': 2020,
+            'dateRange.end.month': 10,
+            'dateRange.end.day': 1,
+        }
+        today = datetime.date(year=2020, month=11, day=10)
+
+        actual_start_date, actual_end_date, actual_params = shift_sync_window(params, today, 30)
+
+        self.assertEqual(expected_start_date, actual_start_date)
+        self.assertEqual(expected_end_date, actual_end_date)
+        self.assertEqual(expected_params, actual_params)
+
+    def test_shift_sync_window_boundary(self):
+        expected_start_date = datetime.date(year=2020, month=10, day=1)
+        expected_end_date = datetime.date(year=2020, month=10, day=15)
+        expected_params = {
+            'dateRange.start.year': expected_start_date.year,
+            'dateRange.start.month': expected_start_date.month,
+            'dateRange.start.day': expected_start_date.day,
+            'dateRange.end.year': expected_end_date.year,
+            'dateRange.end.month': expected_end_date.month,
+            'dateRange.end.day': expected_end_date.day,
+        }
+
+        params = {
+            'dateRange.end.year': 2020,
+            'dateRange.end.month': 10,
+            'dateRange.end.day': 1,
+        }
+        today = datetime.date(year=2020, month=10, day=15)
+
+        actual_start_date, actual_end_date, actual_params = shift_sync_window(params, today)
+
+        self.assertEqual(expected_start_date, actual_start_date)
+        self.assertEqual(expected_end_date, actual_end_date)
+        self.assertEqual(expected_params, actual_params)
+
+
+    def test_merge_responses_empty(self):
+        # This is the assumed key name that holds the records in the response
+        data_key = 'elements'
+        SUCCESSFUL_EMPTY_API_RESPONSE = {'paging' : None,
+                                         data_key : []}
+
+        # We accumulate responses in this list
+        responses = []
+
+        for page in [SUCCESSFUL_EMPTY_API_RESPONSE]:
+            if page.get(data_key):
+                responses.append(page.get(data_key))
+
+        self.assertEqual(dict(),
+                         merge_responses(responses))
+
+    def test_merge_responses_no_overlap(self):
+        expected_output = {
+            '2020-10-1' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+                           'a': 1},
+            '2020-10-2' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 2}},
+                           'b': 2},
+            '2020-10-3' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 3}},
+                           'c': 3},
+            '2020-10-4' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 4}},
+                           'd': 4},
+            '2020-10-5' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 5}},
+                           'e': 5},
+            '2020-10-6' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
+                           'f': 6},
+            }
+
+        data = [
+            [{'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+              'a': 1},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 2}},
+              'b': 2},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 3}},
+              'c': 3},],
+            [{'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 4}},
+              'd': 4},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 5}},
+              'e': 5},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
+              'f': 6},],
+        ]
+
+        actual_output = merge_responses(data)
+
+        self.assertEqual(expected_output, actual_output)
+
+    def test_merge_responses_with_overlap(self):
+        data = [
+            [{'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+              'a': 1},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+              'b': 7},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 2}},
+              'b': 2},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 3}},
+              'c': 3},],
+            [{'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 4}},
+              'd': 4},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 5}},
+              'e': 5},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
+              'f': 6},],
+        ]
+
+        expected_output = {
+            '2020-10-1' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+                           'a': 1, 'b': 7},
+            '2020-10-2' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 2}},
+                           'b': 2},
+            '2020-10-3' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 3}},
+                           'c': 3},
+            '2020-10-4' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 4}},
+                           'd': 4},
+            '2020-10-5' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 5}},
+                           'e': 5},
+            '2020-10-6' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
+                           'f': 6},
+            }
+
+        actual_output = merge_responses(data)
+
+        self.assertEqual(expected_output, actual_output)


### PR DESCRIPTION
# Description of change
This PR
* Updates ` tap_linkedin_ads/transform.py` to not format a string into an empty string just to access a dictionary
* Adds a new function `sync_ad_analytics()` to create date windows and incrementally sync those windows
    * It creates windows of size `DATE_WINDOW_SIZE` long starting at the bookmark or the start date
        * `DATE_WINDOW_SIZE` was made configurable in `sync()` because `sync()` has a handle on the config file
    * It modifies the `endpoints` dictionary declared in `sync()` for `ad_analytics_by_campaign` with the dates of the `window_start` and `window_end`
    * Call `sync_endpoint()` with the new config in order to preserve the "pipeline" that turns raw responses into Singer Messages
        * Things like `transform_json()`, `process_records()`, and all of the bookmarking logic

# Manual QA steps
- Ran the `master` version tap and saved the records
  - I later refer to this as the full sync
- Ran the tap with the new windowing logic
  - I kept only the records from one day
- Wrote a little script to create dictionaries from a file of Singer Messages, mapping PKs to the full record
- Used `unittest.TestCase.assertDictEqual` to do a dictionary diff of records from the two syncs
- Confirmed that every record in the one day sync appears in the full sync
- Confirmed that every record in the full sync with the same date as the one day sync appears in the one day sync
 
- Confident that one day works, I ran the same test for the whole date range

# Risks
- Low given that we were able to compare raw Singer Messages from the two versions of the tap
 
# Rollback steps
 - revert this branch
