### PR TITLE
Sync all fields

### DIFF
--- a/tap_linkedin_ads/schema.py
+++ b/tap_linkedin_ads/schema.py
@@ -78,6 +78,8 @@ def get_schemas():
         if stream_name in ('ad_analytics_by_campaign', 'ad_analytics_by_creative'):
             mdata_map = metadata.to_map(mdata)
             mdata_map[('properties', 'date_range')]['inclusion'] = 'automatic'
+            mdata_map[('properties', 'pivot')]['inclusion'] = 'automatic'
+            mdata_map[('properties', 'pivot_value')]['inclusion'] = 'automatic'
             mdata = metadata.to_list(mdata_map)
 
         field_metadata[stream_name] = mdata

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -299,10 +299,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches,too-many-statements
                                                          for field in selected_fields(catalog.get_stream(child_stream_name))
                                                          if snake_case_to_camel_case(field) in FIELDS_AVAILABLE_FOR_AD_ANALYTICS_V2]
 
-                                field_count = len(valid_selected_fields)
-                                if field_count > 20:
-                                    raise RuntimeError("LinkedIn's API limits the field count for {} to 20 metrics (You have selected {}).".format(child_stream_name, field_count))
-
                                 child_endpoint_config['params']['fields'] = ','.join(valid_selected_fields)
 
                         LOGGER.info('Syncing: %s, parent_stream: %s, parent_id: %s',

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -682,7 +682,7 @@ def sync_ad_analytics(client, catalog, state, last_datetime, stream_name, path, 
     # `pivot`, and `pivotValue`
     MAX_CHUNK_LENGTH = 17
 
-    max_bookmark_value = strptime_to_utc(last_datetime),
+    max_bookmark_value = last_datetime
     last_datetime_dt = strptime_to_utc(last_datetime) - timedelta(days=7)
 
     window_start_date = last_datetime_dt.date()
@@ -760,7 +760,7 @@ def sync_ad_analytics(client, catalog, state, last_datetime, stream_name, path, 
                 records=transformed_data,
                 time_extracted=time_extracted,
                 bookmark_field=bookmark_field,
-                max_bookmark_value=strptime_to_utc(last_datetime),
+                max_bookmark_value=last_datetime,
                 last_datetime=strftime(last_datetime_dt),
                 parent=parent,
                 parent_id=parent_id)

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -306,7 +306,7 @@ def sync_endpoint(client,
                                 client=client,
                                 catalog=catalog,
                                 state=state,
-                                start_date=last_datetime,
+                                last_datetime=last_datetime,
                                 stream_name=child_stream_name,
                                 path=child_path,
                                 endpoint_config=child_endpoint_config,
@@ -682,6 +682,7 @@ def sync_ad_analytics(client, catalog, state, last_datetime, stream_name, path, 
     # `pivot`, and `pivotValue`
     MAX_CHUNK_LENGTH = 17
 
+    max_bookmark_value = strptime_to_utc(last_datetime),
     last_datetime_dt = strptime_to_utc(last_datetime) - timedelta(days=7)
 
     window_start_date = last_datetime_dt.date()
@@ -759,7 +760,7 @@ def sync_ad_analytics(client, catalog, state, last_datetime, stream_name, path, 
                 records=transformed_data,
                 time_extracted=time_extracted,
                 bookmark_field=bookmark_field,
-                max_bookmark_value=strptime_to_utc(start_date),
+                max_bookmark_value=strptime_to_utc(last_datetime),
                 last_datetime=strftime(last_datetime_dt),
                 parent=parent,
                 parent_id=parent_id)

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -656,6 +656,8 @@ def sync_ad_analytics(client,
                       id_fields=None,
                       parent=None,
                       parent_id=None):
+def split_into_chunks(fields, chunk_length):
+    return (fields[x:x+chunk_length] for x in range(0, len(fields), chunk_length))
     # pylint: disable=too-many-branches,too-many-statements,unused-argument
 
     # start_date here is not the config's start date, it's the bookmark

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -680,6 +680,19 @@ def shift_sync_window(params, today):
                   'dateRange.end.year': new_end.year,}
     return current_end, new_end, new_params
 
+def merge_responses(data):
+
+    full_records = dict()
+    for page in data:
+        for element in page:
+            temp_start = element['dateRange']['start']
+            string_start = '{}-{}-{}'.format(temp_start['year'], temp_start['month'], temp_start['day'])
+            if string_start in full_records:
+                full_records[string_start].update(element)
+            else:
+                full_records[string_start] = element
+    return full_records
+
     # pylint: disable=too-many-branches,too-many-statements,unused-argument
 
     # start_date here is not the config's start date, it's the bookmark

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -764,7 +764,7 @@ def sync_ad_analytics(client, catalog, state, start_date, stream_name, path, end
                                           stream_name)[data_key]
         if not transformed_data:
             LOGGER.info('No transformed_data')
-            max_bookmark_value = max_bookmark
+            #max_bookmark_value = max_bookmark
         else:
             max_bookmark_value, record_count = process_records(
                 catalog=catalog,
@@ -772,7 +772,7 @@ def sync_ad_analytics(client, catalog, state, start_date, stream_name, path, end
                 records=transformed_data,
                 time_extracted=time_extracted,
                 bookmark_field=bookmark_field,
-                max_bookmark_value=max_bookmark,
+                max_bookmark_value=strftime(max_bookmark),
                 last_datetime=last_datetime,
                 parent=parent,
                 parent_id=parent_id)
@@ -791,15 +791,17 @@ def sync_ad_analytics(client, catalog, state, start_date, stream_name, path, end
         #     second=0,
         #     tzinfo=pytz.UTC
         # )
+        #max_bookmark = strptime_to_utc(max(strftime(max_bookmark), max_bookmark_value))
 
-        max_bookmark = max(max_bookmark, max_bookmark_value)
+        max_bookmark_value
 
         window_start_date, window_end_date, static_params = shift_sync_window(static_params, today)
 
         if window_start_date == window_end_date:
             break
 
-    return total_records, strftime(max_bookmark)
+    # return total_records, strftime(max_bookmark)
+    return total_records, max_bookmark_value
 
 def sync_analytics_endpoint(client, stream_name, path, query_string, bookmark_query_field=None):
     page = 1

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -658,6 +658,28 @@ def sync_ad_analytics(client,
                       parent_id=None):
 def split_into_chunks(fields, chunk_length):
     return (fields[x:x+chunk_length] for x in range(0, len(fields), chunk_length))
+
+def shift_sync_window(params, today):
+    current_end = datetime.date(
+        year=params['dateRange.end.year'],
+        month=params['dateRange.end.month'],
+        day=params['dateRange.end.day'],
+    )
+    new_end = current_end + timedelta(days=DATE_WINDOW_SIZE)
+
+    if new_end > today:
+        new_end = today
+
+    new_params = {**params,
+                  'dateRange.start.day': current_end.day,
+                  'dateRange.start.month': current_end.month,
+                  'dateRange.start.year': current_end.year,
+
+                  'dateRange.end.day': new_end.day,
+                  'dateRange.end.month': new_end.month,
+                  'dateRange.end.year': new_end.year,}
+    return current_end, new_end, new_params
+
     # pylint: disable=too-many-branches,too-many-statements,unused-argument
 
     # start_date here is not the config's start date, it's the bookmark

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -15,11 +15,11 @@ DATE_WINDOW_SIZE = 30 # days
 FIELDS_AVAILABLE_FOR_AD_ANALYTICS_V2 = {
     'actionClicks',
     'adUnitClicks',
-    'approximateUniqueImpressions', #Add
-    'cardClicks', #Add
-    'cardImpressions', #Add
+    'approximateUniqueImpressions',
+    'cardClicks',
+    'cardImpressions',
     'clicks',
-    'commentLikes', #Add
+    'commentLikes',
     'comments',
     'companyPageClicks',
     'conversionValueInLocalCurrency',
@@ -661,7 +661,6 @@ def shift_sync_window(params, today):
     return current_end, new_end, new_params
 
 def merge_responses(data):
-
     full_records = dict()
     for page in data:
         for element in page:
@@ -709,13 +708,13 @@ def sync_ad_analytics(client, catalog, state, start_date, stream_name, path, end
                              for field in selected_fields(catalog.get_stream(stream_name))
                              if snake_case_to_camel_case(field) in FIELDS_AVAILABLE_FOR_AD_ANALYTICS_V2]
 
-    # When testing the API, if the fields in `field` all return `0` or
-    # `"0"`, then the API returns its empty response.
+    # When testing the API, if the fields in `field` all return `0` then
+    # the API returns its empty response.
 
     # However, the API distinguishes between a day with non-null values
-    # (even if this means the values are all `0` or `"0"`) and a day with
-    # null values. We found that requesting these fields give you the days
-    # with non-null values
+    # (even if this means the values are all `0`) and a day with null
+    # values. We found that requesting these fields give you the days with
+    # non-null values
     first_chunk = [['dateRange', 'pivot', 'pivotValue']]
 
     chunks = first_chunk + list(split_into_chunks(valid_selected_fields, MAX_CHUNK_LENGTH))
@@ -776,7 +775,6 @@ def sync_ad_analytics(client, catalog, state, start_date, stream_name, path, end
         if window_start_date == window_end_date:
             break
 
-    # return total_records, strftime(max_bookmark)
     return total_records, max_bookmark_value
 
 def sync_analytics_endpoint(client, stream_name, path, query_string):

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -639,13 +639,16 @@ def selected_fields(catalog_for_stream):
 def split_into_chunks(fields, chunk_length):
     return (fields[x:x+chunk_length] for x in range(0, len(fields), chunk_length))
 
-def shift_sync_window(params, today):
+def shift_sync_window(params, today, forced_window_size=None):
     current_end = datetime.date(
         year=params['dateRange.end.year'],
         month=params['dateRange.end.month'],
         day=params['dateRange.end.day'],
     )
-    new_end = current_end + timedelta(days=DATE_WINDOW_SIZE)
+    if forced_window_size:
+        new_end = current_end + timedelta(days=forced_window_size)
+    else:
+        new_end = current_end + timedelta(days=DATE_WINDOW_SIZE)
 
     if new_end > today:
         new_end = today

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -673,7 +673,7 @@ def merge_responses(data):
     return full_records
 
 
-def sync_ad_analytics(client, catalog, state, start_date, stream_name, path, endpoint_config, data_key, static_params,
+def sync_ad_analytics(client, catalog, state, last_datetime, stream_name, path, endpoint_config, data_key, static_params,
                       bookmark_query_field=None, bookmark_field=None, id_fields=None, parent=None, parent_id=None):
     # pylint: disable=too-many-branches,too-many-statements,unused-argument
 
@@ -682,10 +682,7 @@ def sync_ad_analytics(client, catalog, state, start_date, stream_name, path, end
     # `pivot`, and `pivotValue`
     MAX_CHUNK_LENGTH = 17
 
-    # start_date here is not the config's start date, it's the bookmark
-    # value, which can fall back to the config's start date
-    max_bookmark = strptime_to_utc(start_date)
-    last_datetime_dt = max_bookmark - timedelta(days=7)
+    last_datetime_dt = strptime_to_utc(last_datetime) - timedelta(days=7)
 
     window_start_date = last_datetime_dt.date()
     window_end_date = window_start_date + timedelta(days=DATE_WINDOW_SIZE)
@@ -762,7 +759,7 @@ def sync_ad_analytics(client, catalog, state, start_date, stream_name, path, end
                 records=transformed_data,
                 time_extracted=time_extracted,
                 bookmark_field=bookmark_field,
-                max_bookmark_value=strftime(max_bookmark),
+                max_bookmark_value=strptime_to_utc(start_date),
                 last_datetime=strftime(last_datetime_dt),
                 parent=parent,
                 parent_id=parent_id)

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,4 +1,5 @@
 import unittest
+from tap_linkedin_ads.sync import get_next_url
 from tap_linkedin_ads.sync import split_into_chunks
 
 
@@ -17,3 +18,24 @@ class TestChunking(unittest.TestCase):
         ]
 
         self.assertEqual(expected, list(actual))
+
+    def test_get_next_url(self):
+        data = {
+            'paging': {
+                'links': []
+            }
+        }
+
+        links = [{'rel': 'next', 'href': '/foo'},]
+
+        expected_1 = None
+        actual_1 = get_next_url(data)
+
+        self.assertEqual(expected_1, actual_1)
+
+        data['paging']['links'] = links
+        expected_2 = 'https://api.linkedin.com/foo'
+        actual_2 = get_next_url(data)
+
+        self.assertEqual(expected_2, actual_2)
+

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,9 +1,11 @@
 import datetime
 import unittest
+from tap_linkedin_ads.sync import DATE_WINDOW_SIZE
 from tap_linkedin_ads.sync import get_next_url
 from tap_linkedin_ads.sync import merge_responses
 from tap_linkedin_ads.sync import shift_sync_window
 from tap_linkedin_ads.sync import split_into_chunks
+
 
 
 class TestSyncUtils(unittest.TestCase):
@@ -18,6 +20,19 @@ class TestSyncUtils(unittest.TestCase):
             [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33],
             [34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50],
             [51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64]
+        ]
+
+        self.assertEqual(expected, list(actual))
+
+    def test_split_into_chunks_2(self):
+        MAX_CHUNK_LENGTH = 17
+        fields = list(range(25))
+
+        actual = split_into_chunks(fields, MAX_CHUNK_LENGTH)
+
+        expected = [
+            [ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16],
+            [17, 18, 19, 20, 21, 22, 23, 24],
         ]
 
         self.assertEqual(expected, list(actual))
@@ -61,7 +76,7 @@ class TestSyncUtils(unittest.TestCase):
         }
         today = datetime.date(year=2020, month=11, day=10)
 
-        actual_start_date, actual_end_date, actual_params = shift_sync_window(params, today)
+        actual_start_date, actual_end_date, actual_params = shift_sync_window(params, today, 30)
 
         self.assertEqual(expected_start_date, actual_start_date)
         self.assertEqual(expected_end_date, actual_end_date)
@@ -109,7 +124,7 @@ class TestSyncUtils(unittest.TestCase):
         self.assertEqual(dict(),
                          merge_responses(responses))
 
-    def test_merge_responses(self):
+    def test_merge_responses_no_overlap(self):
         expected_output = {
             '2020-10-1' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
                            'a': 1},
@@ -139,6 +154,43 @@ class TestSyncUtils(unittest.TestCase):
              {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
               'f': 6},],
         ]
+
+        actual_output = merge_responses(data)
+
+        self.assertEqual(expected_output, actual_output)
+
+    def test_merge_responses_with_overlap(self):
+        data = [
+            [{'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+              'a': 1},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+              'b': 7},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 2}},
+              'b': 2},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 3}},
+              'c': 3},],
+            [{'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 4}},
+              'd': 4},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 5}},
+              'e': 5},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
+              'f': 6},],
+        ]
+
+        expected_output = {
+            '2020-10-1' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+                           'a': 1, 'b': 7},
+            '2020-10-2' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 2}},
+                           'b': 2},
+            '2020-10-3' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 3}},
+                           'c': 3},
+            '2020-10-4' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 4}},
+                           'd': 4},
+            '2020-10-5' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 5}},
+                           'e': 5},
+            '2020-10-6' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
+                           'f': 6},
+            }
 
         actual_output = merge_responses(data)
 

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,6 +1,7 @@
 import datetime
 import unittest
 from tap_linkedin_ads.sync import get_next_url
+from tap_linkedin_ads.sync import merge_responses
 from tap_linkedin_ads.sync import shift_sync_window
 from tap_linkedin_ads.sync import split_into_chunks
 
@@ -91,3 +92,54 @@ class TestSyncUtils(unittest.TestCase):
         self.assertEqual(expected_end_date, actual_end_date)
         self.assertEqual(expected_params, actual_params)
 
+
+    def test_merge_responses_empty(self):
+        # This is the assumed key name that holds the records in the response
+        data_key = 'elements'
+        SUCCESSFUL_EMPTY_API_RESPONSE = {'paging' : None,
+                                         data_key : []}
+
+        # We accumulate responses in this list
+        responses = []
+
+        for page in [SUCCESSFUL_EMPTY_API_RESPONSE]:
+            if page.get(data_key):
+                responses.append(page.get(data_key))
+
+        self.assertEqual(dict(),
+                         merge_responses(responses))
+
+    def test_merge_responses(self):
+        expected_output = {
+            '2020-10-1' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+                           'a': 1},
+            '2020-10-2' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 2}},
+                           'b': 2},
+            '2020-10-3' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 3}},
+                           'c': 3},
+            '2020-10-4' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 4}},
+                           'd': 4},
+            '2020-10-5' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 5}},
+                           'e': 5},
+            '2020-10-6' : {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
+                           'f': 6},
+            }
+
+        data = [
+            [{'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 1}},
+              'a': 1},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 2}},
+              'b': 2},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 3}},
+              'c': 3},],
+            [{'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 4}},
+              'd': 4},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 5}},
+              'e': 5},
+             {'dateRange': {'start': {'year': 2020, 'month': 10, 'day': 6}},
+              'f': 6},],
+        ]
+
+        actual_output = merge_responses(data)
+
+        self.assertEqual(expected_output, actual_output)

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,19 @@
+import unittest
+from tap_linkedin_ads.sync import split_into_chunks
+
+
+class TestChunking(unittest.TestCase):
+    def test_split_into_chunks(self):
+        MAX_CHUNK_LENGTH = 17
+        fields = list(range(65))
+
+        actual = split_into_chunks(fields, MAX_CHUNK_LENGTH)
+
+        expected = [
+            [ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16],
+            [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33],
+            [34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50],
+            [51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64]
+        ]
+
+        self.assertEqual(expected, list(actual))

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,9 +1,11 @@
+import datetime
 import unittest
 from tap_linkedin_ads.sync import get_next_url
+from tap_linkedin_ads.sync import shift_sync_window
 from tap_linkedin_ads.sync import split_into_chunks
 
 
-class TestChunking(unittest.TestCase):
+class TestSyncUtils(unittest.TestCase):
     def test_split_into_chunks(self):
         MAX_CHUNK_LENGTH = 17
         fields = list(range(65))
@@ -38,4 +40,54 @@ class TestChunking(unittest.TestCase):
         actual_2 = get_next_url(data)
 
         self.assertEqual(expected_2, actual_2)
+
+    def test_shift_sync_window_non_boundary(self):
+        expected_start_date = datetime.date(year=2020, month=10, day=1)
+        expected_end_date = datetime.date(year=2020, month=10, day=31)
+        expected_params = {
+            'dateRange.start.year': expected_start_date.year,
+            'dateRange.start.month': expected_start_date.month,
+            'dateRange.start.day': expected_start_date.day,
+            'dateRange.end.year': expected_end_date.year,
+            'dateRange.end.month': expected_end_date.month,
+            'dateRange.end.day': expected_end_date.day,
+        }
+
+        params = {
+            'dateRange.end.year': 2020,
+            'dateRange.end.month': 10,
+            'dateRange.end.day': 1,
+        }
+        today = datetime.date(year=2020, month=11, day=10)
+
+        actual_start_date, actual_end_date, actual_params = shift_sync_window(params, today)
+
+        self.assertEqual(expected_start_date, actual_start_date)
+        self.assertEqual(expected_end_date, actual_end_date)
+        self.assertEqual(expected_params, actual_params)
+
+    def test_shift_sync_window_boundary(self):
+        expected_start_date = datetime.date(year=2020, month=10, day=1)
+        expected_end_date = datetime.date(year=2020, month=10, day=15)
+        expected_params = {
+            'dateRange.start.year': expected_start_date.year,
+            'dateRange.start.month': expected_start_date.month,
+            'dateRange.start.day': expected_start_date.day,
+            'dateRange.end.year': expected_end_date.year,
+            'dateRange.end.month': expected_end_date.month,
+            'dateRange.end.day': expected_end_date.day,
+        }
+
+        params = {
+            'dateRange.end.year': 2020,
+            'dateRange.end.month': 10,
+            'dateRange.end.day': 1,
+        }
+        today = datetime.date(year=2020, month=10, day=15)
+
+        actual_start_date, actual_end_date, actual_params = shift_sync_window(params, today)
+
+        self.assertEqual(expected_start_date, actual_start_date)
+        self.assertEqual(expected_end_date, actual_end_date)
+        self.assertEqual(expected_params, actual_params)
 


### PR DESCRIPTION
# Description of change
LinkedIn made a change to their API to limit the number of fields we can sync. This PR allows you to sync all fields for the `ad_analytics_by_campaign` stream.

The current implementation of `sync_endpoint()` has 3 jobs:
- Get a page of records from the API
- `transform_json()`
- `process_records()`

This PR breaks `ad_analytics_by_campaign` out of that flow, but tries to mirror it as closely as possible.

The only change is to the "Get a page of records from the API" step. Depending on the number of fields selected, we make multiple requests to get the data and then merge these requests into the format that `transform_json()` expects.

# Manual QA steps
- See #17 
- Ran the tap selecting the same fields as the last test in #17, ensured this version produced the same records
- Ran the tap selecting all fields, ensured the fields from the previous sync look the same
- There are some unit tests for the new helper functions

# Risks
- Low because we compared the outputted records to what the previous version of the tap produced
- One thing came up in testing: `Both syncs saw cost_in_local_currency but got different values 49.02123 | 49.02`
  - Rounding is out of our control here
- More concerning is that a more recent sync saw a lower number: `Both syncs saw approximate_unique_impressions but got different values 3639 | 3638`
 
# Rollback steps
 - revert this branch
