### PR TITLE
Fix creatives stream

### DIFF
--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -301,7 +301,7 @@ def sync_endpoint(client,
                                     parent_id)
                         child_path = child_endpoint_config.get('path')
 
-                        if child_stream_name == 'ad_analytics_by_campaign':
+                        if child_stream_name in {'ad_analytics_by_campaign', 'ad_analytics_by_creative'}:
                             child_total_records, child_batch_bookmark_value = sync_ad_analytics(
                                 client=client,
                                 catalog=catalog,

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -668,11 +668,13 @@ def merge_responses(data):
     for page in data:
         for element in page:
             temp_start = element['dateRange']['start']
+            temp_pivotValue = element['pivotValue']
             string_start = '{}-{}-{}'.format(temp_start['year'], temp_start['month'], temp_start['day'])
-            if string_start in full_records:
-                full_records[string_start].update(element)
+            primary_key = (temp_pivotValue, string_start)
+            if primary_key in full_records:
+                full_records[primary_key].update(element)
             else:
-                full_records[string_start] = element
+                full_records[primary_key] = element
     return full_records
 
 


### PR DESCRIPTION
# Description of change
This PR updates the `ad_analytics_by_creative` stream to work like the `ad_analytics_by_campaign` stream.

The change to `merge_responses()` was made because previously for the `ad_analytics_by_campaign` stream the there was only one `campaign_id` per response. But for the `ad_analytics_by_creative` stream, one `campaign_id` can have multiple associated `creative_ids`. So we need both the date of the record and the `creative_id` to uniquely identify the records.

Note though, we derive both the `campaign_id` and `creative_id` field on the `ad_analytics_by_campaign` and `ad_analytics_by_creative` streams respectively from the `pivotValue` field. They both have that field, which is why I  
opted for `temp_pivotValue = element['pivotValue']` over `temp_pivotValue = element.get('pivotValue')`

# Manual QA steps
- Ran a sync with the `master` version of the tap. There was one slight modification to add selected fields as the value of the `fields` query parameter
  - Call this Sync 1
- Made my code change, ran the tap again with the same selected fields and start date as the first sync
   - Call this Sync 2
- Verified that every record in the first sync appeared in the second sync and that the fields were identical
   - Because of the way the new code is written, we get a record with just the PK values for days not found in the first sync
      - This is expected because of some quirk of the API. However, it's still useless records because all you have are the PK fields, every other field is null
- Ran a third sync with all fields selected for the `ad_analytics_by_creative` stream 
   - Call this Sync 3
- Verified that the intersection of the selected fields in Sync 2 and Sync 3 match
 
# Risks
 - Low, this stream is currently broken
 
# Rollback steps
 - revert this branch and bump the version
