### PR TITLE
Tune backoff to retry for up to 10 minutes with jitter to account for 5 minute ads reporting api throttling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-linkedin-ads
             source /usr/local/share/virtualenvs/tap-linkedin-ads/bin/activate
-            pip install -U 'pip<19.2' setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
       - run:
           name: 'pylint'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
+      - add_ssh_keys
       - run:
           name: 'Setup virtual env'
           command: |
@@ -16,8 +17,17 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-linkedin-ads/bin/activate
-            make test
-      - add_ssh_keys
+            make lint
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json /usr/local/share/virtualenvs/tap-linkedin-ads/lib/python*/site-packages/tap_linkedin_ads/schemas/*.json
+      - run:
+          when: always
+          name: 'Integration Tests Setup'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
       - run:
           name: 'Integration Tests'
           command: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.DEFAULT_GOAL := test
+.DEFAULT_GOAL := lint
 
-test:
+lint:
 	pylint tap_linkedin_ads -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring'

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -130,11 +130,15 @@ class LinkedinClient:
             else:
                 return False
 
-
-    @backoff.on_exception(backoff.expo,
-                          (Server5xxError, requests.exceptions.ConnectionError, Server429Error),
-                          max_tries=5,
-                          factor=2)
+    @backoff.on_exception(
+        backoff.expo,
+        (Server5xxError, requests.exceptions.ConnectionError, Server429Error),
+        # Choosing a max time of 10 minutes since documentation for the
+        # [ads reporting api](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting#data-throttling) says
+        # "Data limit for all queries over a 5 min interval: 45 million metric values(where metric value is the value for a metric specified in the fields parameter)."
+        max_time=600, # seconds
+        jitter=backoff.full_jitter,
+    )
     def request(self, method, url=None, path=None, **kwargs):
         if not self.__verified:
             self.__verified = self.check_access_token()


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-2099
and
https://stitchdata.atlassian.net/browse/SUP-2100

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
