### PR TITLE
bump tap version to 1.2.3 and singer-python version to 5.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.3
+  * Changes multipleOf to singer.decimal in schemas and bumps singer-python version
+    [#26](https://github.com/singer-io/tap-linkedin-ads/pull/26)
+
 ## 1.2.2
   * Increase the precision on floating point numbers from 1e-8 to 1e-20
     [#24](https://github.com/singer-io/tap-linkedin-ads/pull/24)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='1.2.2',
+      version='1.2.3',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
@@ -11,7 +11,7 @@ setup(name='tap-linkedin-ads',
       install_requires=[
           'backoff==1.8.0',
           'requests==2.22.0',
-          'singer-python==5.8.1'
+          'singer-python==5.12.1'
       ],
       extras_require={
         'dev': [


### PR DESCRIPTION
# Description of change
Bumps tap version to 1.2.3, and singer-python version to 5.12.1 to include singer.decimals 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
