### PR TITLE
TDL-16348: Add request timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,13 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-linkedin-ads/bin/activate
-            pip install nose
-            nosetests tests/unittests/
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_linkedin_ads --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - run:
           when: always
           name: 'Integration Tests'

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ To generate the **access_token**:
   "start_date": "2019-01-01T00:00:00Z",
   "user_agent": "tap-linkedin-ads <api_user_email@your_company.com>",
   "access_token": "YOUR_ACCESS_TOKEN",
-  "accounts": null
+  "accounts": null,
+  "request_timeout": 300
 }
 ```
 
@@ -206,7 +207,8 @@ To generate the **access_token**:
         "start_date": "2019-01-01T00:00:00Z",
         "user_agent": "tap-linkedin-ads <api_user_email@your_company.com>",
         "access_token": "YOUR_ACCESS_TOKEN",
-        "accounts": "id1, id2, id3"
+        "accounts": "id1, id2, id3",
+        "request_timeout": 300
     }
     ```
     

--- a/config.json.example
+++ b/config.json.example
@@ -2,5 +2,6 @@
   "start_date": "2019-01-01T00:00:00Z",
   "user_agent": "tap-linkedin-ads <api_user_email@your_company.com>",
   "access_token": "xxx",
-  "accounts": null
+  "accounts": null,
+  "request_timeout": 300
 }

--- a/tap_linkedin_ads/__init__.py
+++ b/tap_linkedin_ads/__init__.py
@@ -33,7 +33,8 @@ def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
     with LinkedinClient(access_token=parsed_args.config['access_token'],
-                        user_agent=parsed_args.config['user_agent']) as client:
+                        user_agent=parsed_args.config['user_agent'],
+                        timeout_from_config=parsed_args.config.get('request_timeout')) as client:
         state = {}
         if parsed_args.state:
             state = parsed_args.state

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -199,18 +199,18 @@ class LinkedinClient:
 
     @backoff.on_exception(
         backoff.expo,
+        requests.Timeout,
+        max_tries=5,
+        factor=2
+    )
+    @backoff.on_exception(
+        backoff.expo,
         (Server5xxError, requests.exceptions.ConnectionError, Server429Error),
         # Choosing a max time of 10 minutes since documentation for the
         # [ads reporting api](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting#data-throttling) says
         # "Data limit for all queries over a 5 min interval: 45 million metric values(where metric value is the value for a metric specified in the fields parameter)."
         max_time=600, # seconds
         jitter=backoff.full_jitter,
-    )
-    @backoff.on_exception(
-        backoff.expo,
-        requests.Timeout,
-        max_tries=5,
-        factor=2
     )
     def request(self, method, url=None, path=None, **kwargs):
         if not self.__verified:

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -134,6 +134,8 @@ class LinkedinClient:
 
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.
+    # as 'check_access_token' is also called in 'request' hence added backoff here
+    # instead of 'check_access_token' to avoid backoff 25 times
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.ConnectionError, requests.exceptions.Timeout),
                           max_tries=5,

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -6,6 +6,8 @@ import singer
 
 LOGGER = singer.get_logger()
 
+# set default timeout of 300 seconds
+REQUEST_TIMEOUT = 300
 
 class LinkedInError(Exception):
     pass
@@ -114,12 +116,22 @@ def raise_for_error(response):
 class LinkedinClient:
     def __init__(self,
                  access_token,
-                 user_agent=None):
+                 user_agent=None,
+                 timeout_from_config=None):
         self.__access_token = access_token
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__base_url = None
         self.__verified = False
+
+        # if the 'timeout_from_config' value is 0, "0", "" or not passed then set default value of 300 seconds.
+        if timeout_from_config and float(timeout_from_config):
+            timeout_value = float(timeout_from_config)
+            # update the request timeout for the requests
+            self.request_timeout = timeout_value
+        else:
+            # set the default timeout of 300 seconds
+            self.request_timeout = REQUEST_TIMEOUT
 
     def __enter__(self):
         self.__verified = self.check_access_token()
@@ -129,7 +141,7 @@ class LinkedinClient:
         self.__session.close()
 
     @backoff.on_exception(backoff.expo,
-                          Server5xxError,
+                          (Server5xxError, requests.Timeout),
                           max_tries=5,
                           factor=2)
     def check_access_token(self): #pylint: disable=inconsistent-return-statements
@@ -143,7 +155,8 @@ class LinkedinClient:
         response = self.__session.get(
             # Simple endpoint that returns 1 Account record (to check API/token access):
             url='https://api.linkedin.com/v2/adAccountsV2?q=search&start=0&count=1',
-            headers=headers)
+            headers=headers,
+            timeout=self.request_timeout)
         if response.status_code != 200:
             LOGGER.error('Error status_code = %s', response.status_code)
             raise_for_error(response)
@@ -155,7 +168,7 @@ class LinkedinClient:
                 return False
 
     @backoff.on_exception(backoff.expo,
-                          Server5xxError,
+                          (Server5xxError, requests.Timeout),
                           max_tries=5,
                           factor=2)
     def check_accounts(self, config):
@@ -171,7 +184,8 @@ class LinkedinClient:
             for account in account_list:
                 response = self.__session.get(
                     url='https://api.linkedin.com/v2/adAccountUsersV2?q=accounts&count=1&start=0&accounts=urn:li:sponsoredAccount:{}'.format(account),
-                    headers=headers)
+                    headers=headers,
+                    timeout=self.request_timeout)
 
                 # Account users API will return 400 if account is not in number format.
                 # Account users API will return 404 if provided account is valid number but invalid LinkedIn Ads account
@@ -191,6 +205,12 @@ class LinkedinClient:
         # "Data limit for all queries over a 5 min interval: 45 million metric values(where metric value is the value for a metric specified in the fields parameter)."
         max_time=600, # seconds
         jitter=backoff.full_jitter,
+    )
+    @backoff.on_exception(
+        backoff.expo,
+        requests.Timeout,
+        max_tries=5,
+        factor=2
     )
     def request(self, method, url=None, path=None, **kwargs):
         if not self.__verified:
@@ -220,7 +240,7 @@ class LinkedinClient:
             kwargs['headers']['Content-Type'] = 'application/json'
 
         with metrics.http_request_timer(endpoint) as timer:
-            response = self.__session.request(method, url, **kwargs)
+            response = self.__session.request(method, url, timeout=self.request_timeout, **kwargs)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
 
         if response.status_code != 200:

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -1,6 +1,5 @@
 import backoff
 import requests
-from requests.exceptions import ConnectionError, Timeout
 
 from singer import metrics
 import singer
@@ -144,11 +143,11 @@ class LinkedinClient:
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.
     @backoff.on_exception(backoff.expo,
-                          (Server5xxError, Timeout),
+                          (Server5xxError, requests.exceptions.Timeout),
                           max_tries=5,
                           factor=2)
     @backoff.on_exception(backoff.expo,
-                          (ConnectionError),
+                          (requests.exceptions.ConnectionError),
                           max_tries=5,
                           factor=2)
     def check_access_token(self): #pylint: disable=inconsistent-return-statements
@@ -177,11 +176,11 @@ class LinkedinClient:
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.
     @backoff.on_exception(backoff.expo,
-                          (Server5xxError, Timeout),
+                          (Server5xxError, requests.exceptions.Timeout),
                           max_tries=5,
                           factor=2)
     @backoff.on_exception(backoff.expo,
-                          (ConnectionError),
+                          (requests.exceptions.ConnectionError),
                           max_tries=5,
                           factor=2)
     def check_accounts(self, config):
@@ -212,7 +211,7 @@ class LinkedinClient:
 
     @backoff.on_exception(
         backoff.expo,
-        Timeout,
+        requests.exceptions.Timeout,
         max_tries=5,
         factor=2
     )

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -136,11 +136,7 @@ class LinkedinClient:
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.
     @backoff.on_exception(backoff.expo,
-                          requests.exceptions.Timeout,
-                          max_tries=5,
-                          factor=2)
-    @backoff.on_exception(backoff.expo,
-                          requests.exceptions.ConnectionError,
+                          (requests.exceptions.ConnectionError, requests.exceptions.Timeout),
                           max_tries=5,
                           factor=2)
     def __enter__(self):

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -1,6 +1,5 @@
 import backoff
 import requests
-from requests.exceptions import Timeout, ConnectionError
 
 from singer import metrics
 import singer
@@ -137,11 +136,11 @@ class LinkedinClient:
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.
     @backoff.on_exception(backoff.expo,
-                          Timeout,
+                          requests.exceptions.Timeout,
                           max_tries=5,
                           factor=2)
     @backoff.on_exception(backoff.expo,
-                          ConnectionError,
+                          requests.exceptions.ConnectionError,
                           max_tries=5,
                           factor=2)
     def __enter__(self):

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -126,9 +126,8 @@ class LinkedinClient:
 
         # if the 'timeout_from_config' value is 0, "0", "" or not passed then set default value of 300 seconds.
         if timeout_from_config and float(timeout_from_config):
-            timeout_value = float(timeout_from_config)
             # update the request timeout for the requests
-            self.request_timeout = timeout_value
+            self.request_timeout = float(timeout_from_config)
         else:
             # set the default timeout of 300 seconds
             self.request_timeout = REQUEST_TIMEOUT

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,0 +1,182 @@
+from unittest import mock
+import tap_linkedin_ads.client as client
+import unittest
+import requests
+
+class TestTimeoutValue(unittest.TestCase):
+    """
+        Verify the value of timeout is set as expected
+    """
+
+    def test_timeout_value_not_passed_in_config(self):
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent"
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is default as request timeout is not passed in config
+        self.assertEquals(300, cl.request_timeout)
+
+    def test_timeout_int_value_passed_in_config(self):
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent",
+            "request_timeout": 100
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is same as the value passed in the config
+        self.assertEquals(100.0, cl.request_timeout)
+
+    def test_timeout_string_value_passed_in_config(self):
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent",
+            "request_timeout": "100"
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is same as the value passed in the config
+        self.assertEquals(100.0, cl.request_timeout)
+
+    def test_timeout_empty_value_passed_in_config(self):
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent",
+            "request_timeout": ""
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is default as request timeout is empty in the config
+        self.assertEquals(300, cl.request_timeout)
+
+    def test_timeout_0_value_passed_in_config(self):
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent",
+            "request_timeout": 0.0
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is default as request timeout is zero in the config
+        self.assertEquals(300, cl.request_timeout)
+
+    def test_timeout_string_0_value_passed_in_config(self):
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent",
+            "request_timeout": "0.0"
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is default as request timeout is zero in the config
+        self.assertEquals(300, cl.request_timeout)
+
+@mock.patch("time.sleep")
+class TestTimeoutBackoff(unittest.TestCase):
+    """
+        Verify that we backoff for 5 times for the 'Timeout' error
+    """
+
+    @mock.patch("requests.Session.get")
+    def test_timeout_error__check_access_token(self, mocked_request, mocked_sleep):
+
+        # mock request and raise the 'Timeout' error
+        mocked_request.side_effect = requests.Timeout
+
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent"
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        try:
+            # function call
+            cl.check_access_token()
+        except requests.Timeout:
+            pass
+
+        # verify that we backoff for 5 times
+        self.assertEquals(mocked_request.call_count, 5)
+
+    @mock.patch("requests.Session.get")
+    def test_timeout_error__check_accounts(self, mocked_request, mocked_sleep):
+
+        # mock request and raise the 'Timeout' error
+        mocked_request.side_effect = requests.Timeout
+
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent",
+            "accounts": "1, 2"
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        try:
+            # function call
+            cl.check_accounts(config)
+        except requests.Timeout:
+            pass
+
+        # verify that we backoff for 5 times
+        self.assertEquals(mocked_request.call_count, 5)
+
+    @mock.patch("tap_linkedin_ads.client.LinkedinClient.check_access_token")
+    @mock.patch("requests.Session.request")
+    def test_timeout_error__request(self, mocked_request, mocked_check_access_token, mocked_sleep):
+
+        # mock request and raise the 'Timeout' error
+        mocked_request.side_effect = requests.Timeout
+
+        config = {
+            "access_token": "test_access_token",
+            "user_agent": "test_user_agent",
+            "accounts": "1, 2"
+        }
+
+        # initialize 'LinkedinClient'
+        cl = client.LinkedinClient(access_token=config['access_token'],
+                                   user_agent=config['user_agent'],
+                                   timeout_from_config=config.get('request_timeout'))
+
+        try:
+            # function call
+            cl.request('GET')
+        except requests.Timeout:
+            pass
+
+        # verify that we backoff for 5 times
+        self.assertEquals(mocked_request.call_count, 5)


### PR DESCRIPTION
# Description of change
TDL-16348: Add request timeout
- Use default timeout of 300 seconds if the user does not enter the preferred timeout value

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
