### PR TITLE
Bump version for few changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.2.4
+  * Add Request Timeout [#36](https://github.com/singer-io/tap-linkedin-ads/pull/36)
+  * Handling 4xx responses for adCampaignGroup [#28](https://github.com/singer-io/tap-linkedin-ads/pull/28)
+  * Check Invalid account in discovery mode [#35](https://github.com/singer-io/tap-linkedin-ads/pull/35)
+  * Make Replication Key automatic [#33](https://github.com/singer-io/tap-linkedin-ads/pull/33)
+  * Improve test coverage [#30](https://github.com/singer-io/tap-linkedin-ads/pull/30)
+
 ## 1.2.3
   * Changes multipleOf to singer.decimal in schemas and bumps singer-python version
     [#26](https://github.com/singer-io/tap-linkedin-ads/pull/26)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='1.2.3',
+      version='1.2.4',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
  * Add Request Timeout [#36](https://github.com/singer-io/tap-linkedin-ads/pull/36)
  * Handling 4xx responses for adCampaignGroup [#28](https://github.com/singer-io/tap-linkedin-ads/pull/28)
  * Check Invalid account in discovery mode [#35](https://github.com/singer-io/tap-linkedin-ads/pull/35)
  * Make Replication Key automatic [#33](https://github.com/singer-io/tap-linkedin-ads/pull/33)
  * Improve test coverage [#30](https://github.com/singer-io/tap-linkedin-ads/pull/30)


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
