### PR TITLE
TDL-19157:Refresh Token for Linkedin ads

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,9 @@
 {
-  "start_date": "2019-01-01T00:00:00Z",
+  "client_id": "abc",
+  "client_secret": "xyz",
   "user_agent": "tap-linkedin-ads <api_user_email@your_company.com>",
-  "access_token": "xxx",
-  "accounts": null,
+  "refresh_token": "xyz",
+  "accounts":"null",
+  "start_date": "2019-01-01T00:00:00Z",
   "request_timeout": 300
 }

--- a/tap_linkedin_ads/__init__.py
+++ b/tap_linkedin_ads/__init__.py
@@ -11,6 +11,7 @@ from tap_linkedin_ads.sync import sync as _sync
 
 
 LOGGER = singer.get_logger()
+REQUEST_TIMEOUT = 300
 
 REQUIRED_CONFIG_KEYS = [
     'client_id',

--- a/tap_linkedin_ads/__init__.py
+++ b/tap_linkedin_ads/__init__.py
@@ -12,10 +12,11 @@ from tap_linkedin_ads.sync import sync as _sync
 LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
-    'start_date',
+    'client_id',
+    'client_secret',
+    'refresh_token',
+    'request_timeout',
     'user_agent',
-    'access_token',
-    'accounts'
 ]
 
 def do_discover(client, config):
@@ -29,23 +30,24 @@ def do_discover(client, config):
 
 @singer.utils.handle_top_exception(LOGGER)
 def main():
-
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
+    with LinkedinClient(parsed_args.config['client_id'],
+                      parsed_args.config['client_secret'],
+                      parsed_args.config['refresh_token'],
+                      parsed_args.config.get('request_timeout'),
+                      parsed_args.config['user_agent'],
+                      ) as client:
 
-    with LinkedinClient(access_token=parsed_args.config['access_token'],
-                        user_agent=parsed_args.config['user_agent'],
-                        timeout_from_config=parsed_args.config.get('request_timeout')) as client:
         state = {}
         if parsed_args.state:
             state = parsed_args.state
-
+        config = parsed_args.config
         if parsed_args.discover:
             do_discover(client, parsed_args.config)
         elif parsed_args.catalog:
             _sync(client=client,
-                  config=parsed_args.config,
-                  catalog=parsed_args.catalog,
-                  state=state)
-
+                 config=config,
+                 catalog=parsed_args.catalog,
+                 state=state)
 if __name__ == '__main__':
     main()

--- a/tap_linkedin_ads/__init__.py
+++ b/tap_linkedin_ads/__init__.py
@@ -5,9 +5,10 @@ import json
 import argparse
 import singer
 from singer import metadata, utils
-from tap_linkedin_ads.client import LinkedinClient
+from tap_linkedin_ads.client import LinkedinClient, REQUEST_TIMEOUT
 from tap_linkedin_ads.discover import discover
 from tap_linkedin_ads.sync import sync as _sync
+
 
 LOGGER = singer.get_logger()
 
@@ -15,7 +16,6 @@ REQUIRED_CONFIG_KEYS = [
     'client_id',
     'client_secret',
     'refresh_token',
-    'request_timeout',
     'user_agent',
 ]
 
@@ -34,7 +34,7 @@ def main():
     with LinkedinClient(parsed_args.config['client_id'],
                         parsed_args.config['client_secret'],
                         parsed_args.config['refresh_token'],
-                        parsed_args.config.get('request_timeout'),
+                        REQUEST_TIMEOUT,
                         parsed_args.config['user_agent'],
                        ) as client:
 

--- a/tap_linkedin_ads/__init__.py
+++ b/tap_linkedin_ads/__init__.py
@@ -32,11 +32,11 @@ def do_discover(client, config):
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     with LinkedinClient(parsed_args.config['client_id'],
-                      parsed_args.config['client_secret'],
-                      parsed_args.config['refresh_token'],
-                      parsed_args.config.get('request_timeout'),
-                      parsed_args.config['user_agent'],
-                      ) as client:
+                        parsed_args.config['client_secret'],
+                        parsed_args.config['refresh_token'],
+                        parsed_args.config.get('request_timeout'),
+                        parsed_args.config['user_agent'],
+                       ) as client:
 
         state = {}
         if parsed_args.state:
@@ -46,8 +46,8 @@ def main():
             do_discover(client, parsed_args.config)
         elif parsed_args.catalog:
             _sync(client=client,
-                 config=config,
-                 catalog=parsed_args.catalog,
-                 state=state)
+                  config=config,
+                  catalog=parsed_args.catalog,
+                  state=state)
 if __name__ == '__main__':
     main()

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -190,7 +190,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
         data = response.json()
         self.__access_token = data['access_token']
         self.__expires = datetime.utcnow() + timedelta(seconds=data['expires_in'])
-        LOGGER.info('Authorized, token expires = {}'.format(self.__expires))
+        LOGGER.info('Authorized, token expires = %s', format(self.__expires))
 
     @backoff.on_exception(backoff.expo,
                           Server5xxError,

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -1,6 +1,6 @@
+from datetime import datetime, timedelta
 import backoff
 import requests
-from datetime import datetime, timedelta
 
 from singer import metrics
 import singer
@@ -117,8 +117,8 @@ def raise_for_error(response):
     exc = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("raise_exception", LinkedInError)
     raise exc(message) from None
 
-class LinkedinClient:
-    def __init__(self,
+class LinkedinClient: # pylint: disable=too-many-instance-attributes
+    def __init__(self, # pylint: disable=too-many-arguments
                  client_id,
                  client_secret,
                  refresh_token,
@@ -131,7 +131,8 @@ class LinkedinClient:
         self.__access_token = None
         self.__expires = None
         self.__session = requests.Session()
-        self.base_url = None
+        self.__base_url = None
+        self.__verified = None
         # if request_timeout is other than 0,"0" or "" then use request_timeout
         if request_timeout and float(request_timeout):
             request_timeout = float(request_timeout)
@@ -159,6 +160,7 @@ class LinkedinClient:
                           max_tries=5,
                           factor=2)
     def get_access_token(self):
+        """"""
         # The refresh_token never expires and may be used many times to generate each access_token
         # Since the refresh_token does not expire, it is not included in get access_token response
         if self.__access_token is not None and self.__expires > datetime.utcnow():
@@ -189,10 +191,6 @@ class LinkedinClient:
         self.__access_token = data['access_token']
         self.__expires = datetime.utcnow() + timedelta(seconds=data['expires_in'])
         LOGGER.info('Authorized, token expires = {}'.format(self.__expires))
-
-    def __enter__(self):
-        self.get_access_token()
-        return self
 
     @backoff.on_exception(backoff.expo,
                           Server5xxError,

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -298,8 +298,6 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
 
         if response.status_code != 200:
             raise_for_error(response)
-        print("+++++++++++++++++")
-        print(response.json())
         return response.json()
 
     def get(self, url=None, path=None, **kwargs):

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -149,7 +149,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
                           max_tries=5,
                           factor=2)
     def __enter__(self):
-        self.__verified = self.check_access_token()
+        self.__verified = self.get_access_token()
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
@@ -301,7 +301,8 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
 
         if response.status_code != 200:
             raise_for_error(response)
-
+        print("+++++++++++++++++")
+        print(response.json())
         return response.json()
 
     def get(self, url=None, path=None, **kwargs):

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -1,10 +1,14 @@
 import backoff
 import requests
+from datetime import datetime, timedelta
 
 from singer import metrics
 import singer
 
 LOGGER = singer.get_logger()
+BASE_URL = 'https://api.linkedin.com/v2'
+LINKEDIN_TOKEN_URI = 'https://www.linkedin.com/oauth/v2/accessToken'
+
 
 # set default timeout of 300 seconds
 REQUEST_TIMEOUT = 300
@@ -115,22 +119,25 @@ def raise_for_error(response):
 
 class LinkedinClient:
     def __init__(self,
-                 access_token,
-                 user_agent=None,
-                 timeout_from_config=None):
-        self.__access_token = access_token
+                 client_id,
+                 client_secret,
+                 refresh_token,
+                 request_timeout=REQUEST_TIMEOUT,
+                 user_agent=None):
+        self.__client_id = client_id
+        self.__client_secret = client_secret
+        self.__refresh_token = refresh_token
         self.__user_agent = user_agent
+        self.__access_token = None
+        self.__expires = None
         self.__session = requests.Session()
-        self.__base_url = None
-        self.__verified = False
-
-        # if the 'timeout_from_config' value is 0, "0", "" or not passed then set default value of 300 seconds.
-        if timeout_from_config and float(timeout_from_config):
-            # update the request timeout for the requests
-            self.request_timeout = float(timeout_from_config)
-        else:
-            # set the default timeout of 300 seconds
-            self.request_timeout = REQUEST_TIMEOUT
+        self.base_url = None
+        # if request_timeout is other than 0,"0" or "" then use request_timeout
+        if request_timeout and float(request_timeout):
+            request_timeout = float(request_timeout)
+        else: # If value is 0,"0" or "" then set default to 300 seconds.
+            request_timeout = REQUEST_TIMEOUT
+        self.request_timeout = request_timeout
 
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.
@@ -146,6 +153,46 @@ class LinkedinClient:
 
     def __exit__(self, exception_type, exception_value, traceback):
         self.__session.close()
+
+    @backoff.on_exception(backoff.expo,
+                          Server5xxError,
+                          max_tries=5,
+                          factor=2)
+    def get_access_token(self):
+        # The refresh_token never expires and may be used many times to generate each access_token
+        # Since the refresh_token does not expire, it is not included in get access_token response
+        if self.__access_token is not None and self.__expires > datetime.utcnow():
+            return
+
+        headers = {}
+        if self.__user_agent:
+            headers['User-Agent'] = self.__user_agent
+
+        response = self.__session.post(
+            url=LINKEDIN_TOKEN_URI,
+            headers=headers,
+            data={
+                'grant_type': 'refresh_token',
+                'client_id': self.__client_id,
+                'client_secret': self.__client_secret,
+                'refresh_token': self.__refresh_token,
+            },
+            timeout=self.request_timeout)
+
+        if response.status_code >= 500:
+            raise Server5xxError()
+
+        if response.status_code != 200:
+            raise_for_error(response)
+
+        data = response.json()
+        self.__access_token = data['access_token']
+        self.__expires = datetime.utcnow() + timedelta(seconds=data['expires_in'])
+        LOGGER.info('Authorized, token expires = {}'.format(self.__expires))
+
+    def __enter__(self):
+        self.get_access_token()
+        return self
 
     @backoff.on_exception(backoff.expo,
                           Server5xxError,
@@ -223,6 +270,7 @@ class LinkedinClient:
         factor=2
     )
     def request(self, method, url=None, path=None, **kwargs):
+        self.get_access_token()
         if not self.__verified:
             self.__verified = self.check_access_token()
 

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -181,9 +181,6 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
             },
             timeout=self.request_timeout)
 
-        if response.status_code >= 500:
-            raise Server5xxError()
-
         if response.status_code != 200:
             raise_for_error(response)
 
@@ -270,7 +267,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
     def request(self, method, url=None, path=None, **kwargs):
         self.get_access_token()
         if not self.__verified:
-            self.__verified = self.check_access_token()
+            self.__verified = self.get_access_token()
 
         if not url and self.__base_url is None:
             self.__base_url = 'https://api.linkedin.com/v2'

--- a/tests/base.py
+++ b/tests/base.py
@@ -21,7 +21,10 @@ class TestLinkedinAdsBase(unittest.TestCase):
 
     def setUp(self):
         missing_envs = [x for x in [
-            "TAP_LINKEDIN_ADS_ACCESS_TOKEN", "TAP_LINKEDIN_ADS_ACCOUNTS"
+            "TAP_LINKEDIN_ADS_CLIENT_ID",
+            "TAP_LINKEDIN_ADS_CLIENT_SECRET",
+            "TAP_LINKEDIN_ADS_REFRESH_TOKEN",
+            "TAP_LINKEDIN_ADS_ACCOUNTS"
         ] if os.getenv(x) is None]
         if missing_envs:
             raise Exception("Missing environment variables: {}".format(missing_envs))
@@ -49,8 +52,9 @@ class TestLinkedinAdsBase(unittest.TestCase):
 
     def get_credentials(self):
         return {
-            'access_token': os.getenv("TAP_LINKEDIN_ADS_ACCESS_TOKEN")
-        }
+            "client_id": os.getenv("TAP_LINKEDIN_ADS_CLIENT_ID"),
+            "client_secret": os.getenv("TAP_LINKEDIN_ADS_CLIENT_SECRET"),
+            "refresh_token": os.getenv("TAP_LINKEDIN_ADS_REFRESH_TOKEN"),        }
 
     @staticmethod
     def expected_check_streams():

--- a/tests/unittests/test_account_number.py
+++ b/tests/unittests/test_account_number.py
@@ -46,7 +46,7 @@ class TestValidLinkedInAccount(unittest.TestCase):
         '''
         mocked_request.return_value = get_response(200, raise_error = True)
         config = {"accounts": "1111, 2222"}
-        client = _client.LinkedinClient('')
+        client = _client.LinkedinClient('client_id','client_secret','refresh_token')
         tap_linkedin_ads.do_discover(client, config)
         self.assertEquals(mocked_discover.call_count, 1)
 
@@ -56,7 +56,7 @@ class TestValidLinkedInAccount(unittest.TestCase):
         '''
         mocked_request.return_value = get_response(404, raise_error = True)
         config = {"accounts": "1111, 2222"}
-        client = _client.LinkedinClient('')
+        client = _client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             tap_linkedin_ads.do_discover(client, config)
         except Exception as e:
@@ -71,7 +71,7 @@ class TestValidLinkedInAccount(unittest.TestCase):
         '''
         mocked_request.return_value = get_response(400, raise_error = True)
         config = {"accounts": "aaa, bbb"}
-        client = _client.LinkedinClient('')
+        client = _client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             tap_linkedin_ads.do_discover(client, config)
         except Exception as e:

--- a/tests/unittests/test_adCampaignGroup_4XX.py
+++ b/tests/unittests/test_adCampaignGroup_4XX.py
@@ -46,7 +46,7 @@ class TestExceptionHandling(unittest.TestCase):
 
         mocked_request.return_value = get_response(400, json = json, raise_error = True)
 
-        client = _client.LinkedinClient("access_token")
+        client = _client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             client.request("GET")
         except _client.LinkedInBadRequestError as e:
@@ -59,7 +59,7 @@ class TestExceptionHandling(unittest.TestCase):
 
         mocked_request.return_value = get_response(400, json = json, raise_error = True)
 
-        client = _client.LinkedinClient("access_token")
+        client = _client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             client.request("GET")
         except _client.LinkedInBadRequestError as e:
@@ -68,7 +68,7 @@ class TestExceptionHandling(unittest.TestCase):
     def test_400_error_empty_json(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
 
-        client = _client.LinkedinClient("access_token")
+        client = _client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             client.request("GET")
         except _client.LinkedInBadRequestError as e:
@@ -81,7 +81,7 @@ class TestExceptionHandling(unittest.TestCase):
 
         mocked_request.return_value = get_response(404, json = json, raise_error = True)
 
-        client = _client.LinkedinClient("access_token")
+        client = _client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             client.request("GET")
         except _client.LinkedInNotFoundError as e:
@@ -90,7 +90,7 @@ class TestExceptionHandling(unittest.TestCase):
     def test_404_error_empty_json(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(404, raise_error = True)
 
-        client = _client.LinkedinClient("access_token")
+        client = _client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             client.request("GET")
         except _client.LinkedInNotFoundError as e:

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -25,12 +25,12 @@ def get_response(status_code, json={}, raise_error=False):
     return Mockresponse(status_code, json, raise_error)
 
 @mock.patch("requests.Session.request")
-@mock.patch("tap_linkedin_ads.client.LinkedinClient.check_access_token")
+@mock.patch("tap_linkedin_ads.client.LinkedinClient.client_id")
 class TestExceptionHandling(unittest.TestCase):
 
     def test_400_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInBadRequestError as e:
@@ -38,7 +38,7 @@ class TestExceptionHandling(unittest.TestCase):
 
     def test_401_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(401, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInUnauthorizedError as e:
@@ -46,7 +46,7 @@ class TestExceptionHandling(unittest.TestCase):
 
     def test_403_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(403, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInForbiddenError as e:
@@ -54,7 +54,7 @@ class TestExceptionHandling(unittest.TestCase):
 
     def test_404_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(404, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInNotFoundError as e:
@@ -62,7 +62,7 @@ class TestExceptionHandling(unittest.TestCase):
 
     def test_405_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(405, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInMethodNotAllowedError as e:
@@ -70,7 +70,7 @@ class TestExceptionHandling(unittest.TestCase):
 
     def test_411_error_custom_message(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(411, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInLengthRequiredError as e:
@@ -81,7 +81,7 @@ class TestExceptionHandling(unittest.TestCase):
                             "status": 400,
                             "code": "BAD_REQUEST"}
         mocked_request.return_value = get_response(400, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInBadRequestError as e:
@@ -92,7 +92,7 @@ class TestExceptionHandling(unittest.TestCase):
                             "status": 401,
                             "code": "UNAUTHORIZED"}
         mocked_request.return_value = get_response(401, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInUnauthorizedError as e:
@@ -103,7 +103,7 @@ class TestExceptionHandling(unittest.TestCase):
                             "status": 403,
                             "code": "FORBIDDEN"}
         mocked_request.return_value = get_response(403, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInForbiddenError as e:
@@ -114,7 +114,7 @@ class TestExceptionHandling(unittest.TestCase):
                             "status": 404,
                             "code": "NOT_FOUND"}
         mocked_request.return_value = get_response(404, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInNotFoundError as e:
@@ -125,7 +125,7 @@ class TestExceptionHandling(unittest.TestCase):
                             "status": 405,
                             "code": "METHOD_NOT_ALLOWED"}
         mocked_request.return_value = get_response(405, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInMethodNotAllowedError as e:
@@ -136,7 +136,7 @@ class TestExceptionHandling(unittest.TestCase):
                             "status": 411,
                             "code": "LENGTH_REQUIRED"}
         mocked_request.return_value = get_response(411, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInLengthRequiredError as e:
@@ -148,7 +148,7 @@ class TestExceptionHandling(unittest.TestCase):
                             "status": 401,
                             "code": "UNAUTHORIZED"}
         mocked_request.return_value = get_response(401, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.request("GET")
         except client.LinkedInUnauthorizedError as e:
@@ -160,7 +160,7 @@ class TestAccessToken(unittest.TestCase):
 
     def test_400_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInBadRequestError as e:
@@ -168,7 +168,7 @@ class TestAccessToken(unittest.TestCase):
 
     def test_401_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(401, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInUnauthorizedError as e:
@@ -176,7 +176,7 @@ class TestAccessToken(unittest.TestCase):
 
     def test_403_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(403, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInForbiddenError as e:
@@ -184,7 +184,7 @@ class TestAccessToken(unittest.TestCase):
 
     def test_404_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(404, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInNotFoundError as e:
@@ -192,7 +192,7 @@ class TestAccessToken(unittest.TestCase):
 
     def test_405_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(405, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInMethodNotAllowedError as e:
@@ -200,7 +200,7 @@ class TestAccessToken(unittest.TestCase):
 
     def test_411_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(411, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInLengthRequiredError as e:
@@ -208,7 +208,7 @@ class TestAccessToken(unittest.TestCase):
 
     def test_429_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(429, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInRateLimitExceeededError as e:
@@ -217,7 +217,7 @@ class TestAccessToken(unittest.TestCase):
     @mock.patch("time.sleep")
     def test_500_error_custom_message(self, mocked_sleep, mocked_request):
         mocked_request.return_value = get_response(500, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInInternalServiceError as e:
@@ -227,7 +227,7 @@ class TestAccessToken(unittest.TestCase):
     @mock.patch("time.sleep")
     def test_504_error_custom_message(self, mocked_sleep, mocked_request):
         mocked_request.return_value = get_response(504, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInGatewayTimeoutError as e:
@@ -239,7 +239,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 400,
                             "code": "BAD_REQUEST"}
         mocked_request.return_value = get_response(400, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInBadRequestError as e:
@@ -250,7 +250,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 401,
                             "code": "UNAUTHORIZED"}
         mocked_request.return_value = get_response(401, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInUnauthorizedError as e:
@@ -261,7 +261,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 403,
                             "code": "FORBIDDEN"}
         mocked_request.return_value = get_response(403, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInForbiddenError as e:
@@ -272,7 +272,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 404,
                             "code": "NOT_FOUND"}
         mocked_request.return_value = get_response(404, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInNotFoundError as e:
@@ -283,7 +283,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 405,
                             "code": "METHOD_NOT_ALLOWED"}
         mocked_request.return_value = get_response(405, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInMethodNotAllowedError as e:
@@ -294,7 +294,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 411,
                             "code": "LENGTH_REQUIRED"}
         mocked_request.return_value = get_response(411, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInLengthRequiredError as e:
@@ -305,7 +305,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 429,
                             "code": "RATELIMIT_EXCEEDED"}
         mocked_request.return_value = get_response(429, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInRateLimitExceeededError as e:
@@ -317,7 +317,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 500,
                             "code": "INTERNAL_ERROR"}
         mocked_request.return_value = get_response(500, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInInternalServiceError as e:
@@ -330,7 +330,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 504,
                             "code": "GATEWAY_TIMEOUT"}
         mocked_request.return_value = get_response(504, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInGatewayTimeoutError as e:
@@ -343,7 +343,7 @@ class TestAccessToken(unittest.TestCase):
                             "status": 401,
                             "code": "UNAUTHORIZED"}
         mocked_request.return_value = get_response(401, response_json, raise_error = True)
-        linkedIn_client = client.LinkedinClient("access_token")
+        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
             linkedIn_client.check_access_token()
         except client.LinkedInUnauthorizedError as e:

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -25,7 +25,7 @@ def get_response(status_code, json={}, raise_error=False):
     return Mockresponse(status_code, json, raise_error)
 
 @mock.patch("requests.Session.request")
-@mock.patch("tap_linkedin_ads.client.LinkedinClient.client_id")
+@mock.patch("tap_linkedin_ads.client.LinkedinClient.get_access_token")
 class TestExceptionHandling(unittest.TestCase):
 
     def test_400_error_custom_message(self, mocked_access_token, mocked_request):
@@ -40,15 +40,15 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(401, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInUnauthorizedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
 
-    def test_403_error_custom_message(self, mocked_access_token, mocked_request):
+    def test_403_error_custom_message(self,mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(403, raise_error = True)
-        linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
+        linkedIn_client = client.LinkedinClient("client_id","client_secret","refresh_token")
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInForbiddenError as e:
             self.assertEquals(str(e), "HTTP-error-code: 403, Error: User does not have permission to access the resource.")
 
@@ -56,7 +56,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(404, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInNotFoundError as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
@@ -64,7 +64,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(405, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInMethodNotAllowedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 405, Error: The provided HTTP method is not supported by the URL.")
 
@@ -72,7 +72,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(411, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInLengthRequiredError as e:
             self.assertEquals(str(e), "HTTP-error-code: 411, Error: The server refuses to accept the request without a defined Content-Length header.")
 
@@ -83,7 +83,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(400, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInBadRequestError as e:
             self.assertEquals(str(e), "HTTP-error-code: 400, Error: {}".format(response_json.get('message')))
 
@@ -94,7 +94,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(401, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInUnauthorizedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
 
@@ -105,7 +105,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(403, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInForbiddenError as e:
             self.assertEquals(str(e), "HTTP-error-code: 403, Error: {}".format(response_json.get('message')))
 
@@ -116,7 +116,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(404, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInNotFoundError as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
@@ -127,7 +127,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(405, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInMethodNotAllowedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 405, Error: {}".format(response_json.get('message')))
 
@@ -138,7 +138,7 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(411, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInLengthRequiredError as e:
             self.assertEquals(str(e), "HTTP-error-code: 411, Error: {}".format(response_json.get('message')))
 
@@ -150,19 +150,19 @@ class TestExceptionHandling(unittest.TestCase):
         mocked_request.return_value = get_response(401, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.request("GET")
+            linkedIn_client.request("POST")
         except client.LinkedInUnauthorizedError as e:
             mocked_logger.assert_called_with("Your access_token has expired as per LinkedIn’s security policy. Please re-authenticate your connection to generate a new token and resume extraction.")
             self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
 
-@mock.patch("requests.Session.get")
+@mock.patch("requests.Session.post")
 class TestAccessToken(unittest.TestCase):
 
     def test_400_error_custom_message(self, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInBadRequestError as e:
             self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has a bad parameter.")
 
@@ -170,7 +170,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(401, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInUnauthorizedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
 
@@ -178,7 +178,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(403, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInForbiddenError as e:
             self.assertEquals(str(e), "HTTP-error-code: 403, Error: User does not have permission to access the resource.")
 
@@ -186,7 +186,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(404, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInNotFoundError as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
@@ -194,7 +194,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(405, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInMethodNotAllowedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 405, Error: The provided HTTP method is not supported by the URL.")
 
@@ -202,7 +202,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(411, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInLengthRequiredError as e:
             self.assertEquals(str(e), "HTTP-error-code: 411, Error: The server refuses to accept the request without a defined Content-Length header.")
 
@@ -210,7 +210,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(429, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInRateLimitExceeededError as e:
             self.assertEquals(str(e), "HTTP-error-code: 429, Error: API rate limit exceeded, please retry after some time.")
 
@@ -219,7 +219,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(500, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInInternalServiceError as e:
             self.assertEquals(str(e), "HTTP-error-code: 500, Error: An error has occurred at LinkedIn's end.")
         self.assertEquals(mocked_request.call_count, 5)
@@ -229,7 +229,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(504, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInGatewayTimeoutError as e:
             self.assertEquals(str(e), "HTTP-error-code: 504, Error: A gateway timeout occurred. There is a problem at LinkedIn's end.")
         self.assertEquals(mocked_request.call_count, 5)
@@ -241,7 +241,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(400, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInBadRequestError as e:
             self.assertEquals(str(e), "HTTP-error-code: 400, Error: {}".format(response_json.get('message')))
 
@@ -252,7 +252,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(401, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInUnauthorizedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
 
@@ -263,7 +263,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(403, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInForbiddenError as e:
             self.assertEquals(str(e), "HTTP-error-code: 403, Error: {}".format(response_json.get('message')))
 
@@ -274,7 +274,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(404, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInNotFoundError as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: The resource you have specified cannot be found. Either the accounts provided are invalid or you do not have access to the Ad Account.")
 
@@ -285,7 +285,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(405, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInMethodNotAllowedError as e:
             self.assertEquals(str(e), "HTTP-error-code: 405, Error: {}".format(response_json.get('message')))
 
@@ -296,7 +296,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(411, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInLengthRequiredError as e:
             self.assertEquals(str(e), "HTTP-error-code: 411, Error: {}".format(response_json.get('message')))
 
@@ -307,7 +307,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(429, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInRateLimitExceeededError as e:
             self.assertEquals(str(e), "HTTP-error-code: 429, Error: {}".format(response_json.get('message')))
 
@@ -319,7 +319,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(500, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInInternalServiceError as e:
             self.assertEquals(str(e), "HTTP-error-code: 500, Error: {}".format(response_json.get('message')))
         self.assertEquals(mocked_request.call_count, 5)
@@ -332,7 +332,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(504, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInGatewayTimeoutError as e:
             self.assertEquals(str(e), "HTTP-error-code: 504, Error: {}".format(response_json.get('message')))
         self.assertEquals(mocked_request.call_count, 5)
@@ -345,7 +345,7 @@ class TestAccessToken(unittest.TestCase):
         mocked_request.return_value = get_response(401, response_json, raise_error = True)
         linkedIn_client = client.LinkedinClient('client_id','client_secret','refresh_token')
         try:
-            linkedIn_client.check_access_token()
+            linkedIn_client.get_access_token()
         except client.LinkedInUnauthorizedError as e:
             mocked_logger.assert_called_with("Your access_token has expired as per LinkedIn’s security policy. Please re-authenticate your connection to generate a new token and resume extraction.")
             self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))

--- a/tests/unittests/test_sync_endpoint.py
+++ b/tests/unittests/test_sync_endpoint.py
@@ -16,7 +16,7 @@ class TestSyncEndpoint(unittest.TestCase):
     @mock.patch("tap_linkedin_ads.sync.write_schema")
     def test_sync_endpoint_for_reference_organization_id_is_None(self,mock_write_schema,mock_get_selected_streams,mock_process_records,mock_client,mock_should_sync_stream,mock_get_bookmark,mocked_logger):
         
-        client=LinkedinClient("","")
+        client=LinkedinClient('client_id','client_secret','refresh_token')
         catalog = None
         state={'currently_syncing': 'accounts'}
         start_date='2019-06-01T00:00:00Z'

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -9,90 +9,118 @@ class TestTimeoutValue(unittest.TestCase):
     """
 
     def test_timeout_value_not_passed_in_config(self):
+        # config = {
+        #     "access_token": "test_access_token",
+        #     "user_agent": "test_user_agent"
+        # }
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent"
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is not passed in config
         self.assertEquals(300, cl.request_timeout)
 
     def test_timeout_int_value_passed_in_config(self):
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent",
             "request_timeout": 100
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is same as the value passed in the config
         self.assertEquals(100.0, cl.request_timeout)
 
     def test_timeout_string_value_passed_in_config(self):
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent",
             "request_timeout": "100"
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is same as the value passed in the config
         self.assertEquals(100.0, cl.request_timeout)
 
     def test_timeout_empty_value_passed_in_config(self):
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent",
             "request_timeout": ""
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is empty in the config
         self.assertEquals(300, cl.request_timeout)
 
     def test_timeout_0_value_passed_in_config(self):
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent",
             "request_timeout": 0.0
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is zero in the config
         self.assertEquals(300, cl.request_timeout)
 
     def test_timeout_string_0_value_passed_in_config(self):
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent",
             "request_timeout": "0.0"
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is zero in the config
         self.assertEquals(300, cl.request_timeout)
@@ -110,15 +138,19 @@ class TestTimeoutBackoff(unittest.TestCase):
         mocked_request.side_effect = requests.Timeout
 
         config = {
-            "access_token": "test_access_token",
-            "user_agent": "test_user_agent"
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
+            "user_agent": "test_user_agent",
         }
 
         # initialize 'LinkedinClient'
         try:
-            with client.LinkedinClient(access_token=config['access_token'],
-                                       user_agent=config['user_agent'],
-                                       timeout_from_config=config.get('request_timeout')) as cl:
+            with client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout')) as cl:
                 pass
         except requests.Timeout:
             pass
@@ -132,15 +164,19 @@ class TestTimeoutBackoff(unittest.TestCase):
         mocked_request.side_effect = requests.Timeout
 
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent",
             "accounts": "1, 2"
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         try:
             # function call
@@ -157,15 +193,19 @@ class TestTimeoutBackoff(unittest.TestCase):
         mocked_request.side_effect = requests.Timeout
 
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent",
             "accounts": "1, 2"
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         try:
             # function call
@@ -189,15 +229,20 @@ class TestConnectionErrorBackoff(unittest.TestCase):
         mocked_request.side_effect = requests.ConnectionError
 
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
+            "user_agent": "test_user_agent",
             "user_agent": "test_user_agent"
         }
 
         # initialize 'LinkedinClient'
         try:
-            with client.LinkedinClient(access_token=config['access_token'],
-                                       user_agent=config['user_agent'],
-                                       timeout_from_config=config.get('request_timeout')) as cl:
+            with client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout')) as cl:
                 pass
         except requests.ConnectionError:
             pass
@@ -211,15 +256,19 @@ class TestConnectionErrorBackoff(unittest.TestCase):
         mocked_request.side_effect = requests.ConnectionError
 
         config = {
-            "access_token": "test_access_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token":"test_refresh_token",
             "user_agent": "test_user_agent",
             "accounts": "1, 2"
         }
 
         # initialize 'LinkedinClient'
-        cl = client.LinkedinClient(access_token=config['access_token'],
-                                   user_agent=config['user_agent'],
-                                   timeout_from_config=config.get('request_timeout'))
+        cl = client.LinkedinClient(client_id=config['client_id'],
+        client_secret=config['client_secret'],
+        refresh_token=config['refresh_token'],
+        user_agent=config['user_agent'],
+        timeout_from_config=config.get('request_timeout'))
 
         try:
             # function call

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -9,10 +9,6 @@ class TestTimeoutValue(unittest.TestCase):
     """
 
     def test_timeout_value_not_passed_in_config(self):
-        # config = {
-        #     "access_token": "test_access_token",
-        #     "user_agent": "test_user_agent"
-        # }
         config = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
@@ -25,7 +21,7 @@ class TestTimeoutValue(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is not passed in config
         self.assertEquals(300, cl.request_timeout)
@@ -44,7 +40,7 @@ class TestTimeoutValue(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is same as the value passed in the config
         self.assertEquals(100.0, cl.request_timeout)
@@ -63,7 +59,7 @@ class TestTimeoutValue(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is same as the value passed in the config
         self.assertEquals(100.0, cl.request_timeout)
@@ -82,7 +78,7 @@ class TestTimeoutValue(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is empty in the config
         self.assertEquals(300, cl.request_timeout)
@@ -101,7 +97,7 @@ class TestTimeoutValue(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is zero in the config
         self.assertEquals(300, cl.request_timeout)
@@ -120,7 +116,7 @@ class TestTimeoutValue(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is zero in the config
         self.assertEquals(300, cl.request_timeout)
@@ -147,10 +143,10 @@ class TestTimeoutBackoff(unittest.TestCase):
         # initialize 'LinkedinClient'
         try:
             with client.LinkedinClient(client_id=config['client_id'],
-        client_secret=config['client_secret'],
-        refresh_token=config['refresh_token'],
-        user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout')) as cl:
+            client_secret=config['client_secret'],
+            refresh_token=config['refresh_token'],
+            user_agent=config['user_agent'],
+            request_timeout=config.get('request_timeout')) as cl:
                 pass
         except requests.Timeout:
             pass
@@ -176,7 +172,7 @@ class TestTimeoutBackoff(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         try:
             # function call
@@ -205,7 +201,7 @@ class TestTimeoutBackoff(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         try:
             # function call
@@ -242,7 +238,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout')) as cl:
+        request_timeout=config.get('request_timeout')) as cl:
                 pass
         except requests.ConnectionError:
             pass
@@ -268,7 +264,7 @@ class TestConnectionErrorBackoff(unittest.TestCase):
         client_secret=config['client_secret'],
         refresh_token=config['refresh_token'],
         user_agent=config['user_agent'],
-        timeout_from_config=config.get('request_timeout'))
+        request_timeout=config.get('request_timeout'))
 
         try:
             # function call


### PR DESCRIPTION
# Description of change
TDL19157:generate access token programatically using refresh token

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
