### PR TITLE
bump version 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.5
+  * Auto access-token refresh [#41](https://github.com/singer-io/tap-linkedin-ads/pull/41)
+  
 ## 1.2.4
   * Add Request Timeout [#36](https://github.com/singer-io/tap-linkedin-ads/pull/36)
   * Handling 4xx responses for adCampaignGroup [#28](https://github.com/singer-io/tap-linkedin-ads/pull/28)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='1.2.4',
+      version='1.2.5',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
* Auto access-token refresh [#41](https://github.com/singer-io/tap-linkedin-ads/pull/41)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
