### PR TITLE
Bump version 1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.6
+  * Fixed 1.2.5 release issues [#43](https://github.com/singer-io/tap-linkedin-ads/pull/43)
+
 ## 1.2.5
   * Auto access-token refresh [#41](https://github.com/singer-io/tap-linkedin-ads/pull/41)
   

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='1.2.5',
+      version='1.2.6',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Fixed 1.2.5 release issues [#43](https://github.com/singer-io/tap-linkedin-ads/pull/43)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
