### PR TITLE
Add access token introspection to avoid new access token fetch if feasible

### DIFF
--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -211,11 +211,11 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
 
                 data = response.json()
                 self.__expires = datetime.fromtimestamp(data['expires_at'])
-                LOGGER.info(f'Existing token still valid; token expires {self.__expires.strftime("%Y-%m-%d %H:%M:%S")}')
+                LOGGER.info('Existing token still valid; token expires %s', self.__expires.strftime("%Y-%m-%d %H:%M:%S"))
                 return
 
             if self.__expires > datetime.utcnow():
-                LOGGER.info(f'Existing token still valid; token expires {self.__expires.strftime("%Y-%m-%d %H:%M:%S")}')
+                LOGGER.info(f'Existing token still valid; token expires %s', self.__expires.strftime("%Y-%m-%d %H:%M:%S"))
                 return
 
         response = self.__session.post(
@@ -235,7 +235,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
         data = response.json()
         self.__access_token = data['access_token']
         self.__expires = datetime.utcnow() + timedelta(seconds=data['expires_in'])
-        LOGGER.info(f'Retrieved new access token; token expires {self.__expires.strftime("%Y-%m-%d %H:%M:%S")}')
+        LOGGER.info(f'Retrieved new access token; token expires %s', self.__expires.strftime("%Y-%m-%d %H:%M:%S"))
 
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -23,7 +23,6 @@ class Server5xxError(LinkedInError):
 class Server429Error(LinkedInError):
     pass
 
-
 class LinkedInBadRequestError(LinkedInError):
     pass
 
@@ -171,7 +170,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
 
 
     @backoff.on_exception(backoff.expo,
-                          Server5xxError,
+                          (Server5xxError,LinkedInUnauthorizedError),
                           max_tries=5,
                           factor=2)
     def fetch_and_set_access_token(self):

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -170,7 +170,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
 
 
     @backoff.on_exception(backoff.expo,
-                          (Server5xxError,LinkedInUnauthorizedError),
+                          (Server5xxError, LinkedInUnauthorizedError),
                           max_tries=5,
                           factor=2)
     def fetch_and_set_access_token(self):
@@ -215,7 +215,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
                 return
 
             if self.__expires > datetime.utcnow():
-                LOGGER.info(f'Existing token still valid; token expires %s', self.__expires.strftime("%Y-%m-%d %H:%M:%S"))
+                LOGGER.info('Existing token still valid; token expires %s', self.__expires.strftime("%Y-%m-%d %H:%M:%S"))
                 return
 
         response = self.__session.post(
@@ -235,7 +235,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
         data = response.json()
         self.__access_token = data['access_token']
         self.__expires = datetime.utcnow() + timedelta(seconds=data['expires_in'])
-        LOGGER.info(f'Retrieved new access token; token expires %s', self.__expires.strftime("%Y-%m-%d %H:%M:%S"))
+        LOGGER.info('Retrieved new access token; token expires %s', self.__expires.strftime("%Y-%m-%d %H:%M:%S"))
 
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,4 +1,3 @@
-from logging import NullHandler
 from unittest import mock
 import tap_linkedin_ads.client as _client
 import tap_linkedin_ads
@@ -16,8 +15,11 @@ class TestLinkedInClient(unittest.TestCase):
         '''
         client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
 
+        future_time = int(datetime.utcnow().timestamp()) + 100
         mocked_response = mock.Mock()
-        mocked_response.json.return_value = {"expires_at": 1663272887}
+        mocked_response.json.return_value = {
+            "expires_at": future_time
+        }
         mocked_response.status_code = 200
         mocked_post.return_value = mocked_response
 
@@ -26,7 +28,7 @@ class TestLinkedInClient(unittest.TestCase):
 
         client.fetch_and_set_access_token()
         expires = client.get_expires_time()
-        self.assertEqual(expires, datetime.fromtimestamp(1663272887))
+        self.assertEqual(expires, datetime.fromtimestamp(future_time))
 
     def test_access_token_expires_valid(self, mocked_post):
         '''
@@ -34,20 +36,19 @@ class TestLinkedInClient(unittest.TestCase):
         '''
         client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
 
-        test_expires = 2073919961
+        future_time = int(datetime.utcnow().timestamp()) + 100
         mocked_response = mock.MagicMock()
         mocked_response.status_code = 200
         mocked_response.json.return_value = {
             "access_token": "abcdef12345",
-            "expires_at": test_expires,
-            "expires_in": 5184000
+            "expires_at": future_time,
         }
         mocked_post.return_value = mocked_response
 
-        client.set_mock_expires(datetime.fromtimestamp(test_expires))
+        client.set_mock_expires(datetime.fromtimestamp(future_time))
         client.fetch_and_set_access_token()
         expires = client.get_expires_time()
-        self.assertEqual(expires, datetime.fromtimestamp(test_expires))
+        self.assertEqual(expires, datetime.fromtimestamp(future_time))
 
 
     def test_access_token_expires_invalid(self, mocked_post):
@@ -56,20 +57,19 @@ class TestLinkedInClient(unittest.TestCase):
         '''
         client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
 
-        test_expires = 1663693121
+        old_time = int(datetime.utcnow().timestamp()) - 100
         mocked_response = mock.MagicMock()
         mocked_response.status_code = 200
         mocked_response.json.return_value = {
             "access_token": "abcdef12345",
-            "expires_at": test_expires,
             "expires_in": 5184000
         }
         mocked_post.return_value = mocked_response
 
-        client.set_mock_expires(datetime.fromtimestamp(test_expires))
+        client.set_mock_expires(datetime.fromtimestamp(old_time))
         client.fetch_and_set_access_token()
-        expires = client.get_expires_time()
-        self.assertGreater(expires, datetime.fromtimestamp(test_expires))
+        new_expires = client.get_expires_time()
+        self.assertGreater(new_expires, datetime.fromtimestamp(old_time))
 
     def test_no_access_token(self, mocked_post):
         '''
@@ -80,7 +80,7 @@ class TestLinkedInClient(unittest.TestCase):
         expires = client.get_expires_time()
         assert expires is None
 
-        test_expires = 1663693121
+        old_time = int(datetime.utcnow().timestamp()) - 100
         mocked_response = mock.Mock()
         mocked_response.json.return_value = {
             "access_token": "abcdef12345",
@@ -91,4 +91,4 @@ class TestLinkedInClient(unittest.TestCase):
 
         client.fetch_and_set_access_token()
         expires = client.get_expires_time()
-        self.assertGreater(expires, datetime.fromtimestamp(test_expires))
+        self.assertGreater(expires, datetime.fromtimestamp(old_time))

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,92 @@
+from logging import NullHandler
+from unittest import mock
+import tap_linkedin_ads.client as _client
+import tap_linkedin_ads
+import unittest
+import requests
+from datetime import datetime
+import calendar
+
+@mock.patch("requests.Session.post")
+class TestLinkedInClient(unittest.TestCase):
+
+    def test_access_token_empty_expires(self, mocked_post):
+        '''
+        Ensure that we retrieve and set expires for client with no self.__expires
+        '''
+        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
+
+        mocked_response = mock.Mock()
+        mocked_response.json.return_value = {"expires_at": 1663272887}
+        mocked_response.status_code = 200
+        mocked_post.return_value = mocked_response
+
+        expires = client.get_expires_time()
+        assert expires is None
+
+        client.fetch_and_set_access_token()
+        expires = client.get_expires_time()
+        self.assertEqual(expires, datetime.fromtimestamp(1663272887))
+
+    def test_access_token_expires_valid(self, mocked_post):
+        '''
+        Ensure that we check and return on valid self.__expires
+        '''
+        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
+
+        test_expires = 2073919961
+        mocked_response = mock.MagicMock()
+        mocked_response.status_code = 200
+        mocked_response.json.return_value = {
+            "access_token": "abcdef12345",
+            "expires_at": test_expires,
+            "expires_in": 5184000
+        }
+        mocked_post.return_value = mocked_response
+                
+        client.set_mock_expires(datetime.fromtimestamp(test_expires))
+        client.fetch_and_set_access_token()
+        expires = client.get_expires_time()
+        self.assertEqual(expires, datetime.fromtimestamp(test_expires))
+
+
+    def test_access_token_expires_invalid(self, mocked_post):
+        '''
+        Ensure that we check self.__expires and retrieve new access token if it has expired
+        '''
+        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
+
+        test_expires = 1663693121
+        mocked_response = mock.MagicMock()
+        mocked_response.status_code = 200
+        mocked_response.json.return_value = {
+            "access_token": "abcdef12345",
+            "expires_at": test_expires,
+            "expires_in": 5184000
+        }
+        mocked_post.return_value = mocked_response
+
+        client.set_mock_expires(datetime.fromtimestamp(test_expires))
+        client.fetch_and_set_access_token()
+        expires = client.get_expires_time()
+        self.assertGreater(expires, datetime.fromtimestamp(test_expires))
+
+    def test_no_access_token(self, mocked_post):
+        '''
+        Ensure that we get an access token if we don't already have one
+        '''
+        pass
+        # client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
+
+        # test_expires = 1663693121
+        # mocked_response = mock.Mock()
+        # mocked_response.json.return_value = {
+        #     "access_token": "abcdef12345",
+        #     "expires_in": 5184000
+        # }
+        # mocked_response.status_code = 200
+        # mocked_post.return_value = mocked_response
+        
+        # client.fetch_and_set_access_token()
+        # expires = client.get_expires_time()
+        # self.assertGreater(expires, datetime.fromtimestamp(test_expires))

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -43,7 +43,7 @@ class TestLinkedInClient(unittest.TestCase):
             "expires_in": 5184000
         }
         mocked_post.return_value = mocked_response
-                
+
         client.set_mock_expires(datetime.fromtimestamp(test_expires))
         client.fetch_and_set_access_token()
         expires = client.get_expires_time()
@@ -75,18 +75,20 @@ class TestLinkedInClient(unittest.TestCase):
         '''
         Ensure that we get an access token if we don't already have one
         '''
-        pass
-        # client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token')
+        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', None)
 
-        # test_expires = 1663693121
-        # mocked_response = mock.Mock()
-        # mocked_response.json.return_value = {
-        #     "access_token": "abcdef12345",
-        #     "expires_in": 5184000
-        # }
-        # mocked_response.status_code = 200
-        # mocked_post.return_value = mocked_response
-        
-        # client.fetch_and_set_access_token()
-        # expires = client.get_expires_time()
-        # self.assertGreater(expires, datetime.fromtimestamp(test_expires))
+        expires = client.get_expires_time()
+        assert expires is None
+
+        test_expires = 1663693121
+        mocked_response = mock.Mock()
+        mocked_response.json.return_value = {
+            "access_token": "abcdef12345",
+            "expires_in": 5184000
+        }
+        mocked_response.status_code = 200
+        mocked_post.return_value = mocked_response
+
+        client.fetch_and_set_access_token()
+        expires = client.get_expires_time()
+        self.assertGreater(expires, datetime.fromtimestamp(test_expires))

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -23,11 +23,11 @@ class TestLinkedInClient(unittest.TestCase):
         mocked_response.status_code = 200
         mocked_post.return_value = mocked_response
 
-        expires = client.get_expires_time()
+        expires = client.get_expires_time_for_test()
         assert expires is None
 
         client.fetch_and_set_access_token()
-        expires = client.get_expires_time()
+        expires = client.get_expires_time_for_test()
         self.assertEqual(expires, datetime.fromtimestamp(future_time))
 
     def test_access_token_expires_valid(self, mocked_post):
@@ -45,9 +45,9 @@ class TestLinkedInClient(unittest.TestCase):
         }
         mocked_post.return_value = mocked_response
 
-        client.set_mock_expires(datetime.fromtimestamp(future_time))
+        client.set_mock_expires_for_test(datetime.fromtimestamp(future_time))
         client.fetch_and_set_access_token()
-        expires = client.get_expires_time()
+        expires = client.get_expires_time_for_test()
         self.assertEqual(expires, datetime.fromtimestamp(future_time))
 
 
@@ -66,9 +66,9 @@ class TestLinkedInClient(unittest.TestCase):
         }
         mocked_post.return_value = mocked_response
 
-        client.set_mock_expires(datetime.fromtimestamp(old_time))
+        client.set_mock_expires_for_test(datetime.fromtimestamp(old_time))
         client.fetch_and_set_access_token()
-        new_expires = client.get_expires_time()
+        new_expires = client.get_expires_time_for_test()
         self.assertGreater(new_expires, datetime.fromtimestamp(old_time))
 
     def test_no_access_token(self, mocked_post):
@@ -77,7 +77,7 @@ class TestLinkedInClient(unittest.TestCase):
         '''
         client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', None)
 
-        expires = client.get_expires_time()
+        expires = client.get_expires_time_for_test()
         assert expires is None
 
         old_time = int(datetime.utcnow().timestamp()) - 100
@@ -90,5 +90,5 @@ class TestLinkedInClient(unittest.TestCase):
         mocked_post.return_value = mocked_response
 
         client.fetch_and_set_access_token()
-        expires = client.get_expires_time()
+        expires = client.get_expires_time_for_test()
         self.assertGreater(expires, datetime.fromtimestamp(old_time))


### PR DESCRIPTION
# Description of change
LinkedIn seemingly does not appreciate when we fetch new access tokens while a valid one already exists. This has been observed to exhibit itself in the form of 429 errors suggesting that a user has reached a rate limit while trying to use a refresh token to fetch a new access token in discovery. 

This change checks the expiration of an existing access_token (if one is present in the config) and proceeds with that token if so.

# Manual QA steps
 - Tested locally with various access tokens.
 - Added several unittests.
 
# Risks
 - Access Tokens could expire between checking the validity and issuing a request, and this does not provide handling for that case.
 
# Rollback steps
 - revert this branch
