### PR TITLE
minor bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.0
+  * Dictionary based to class based implementation [#48](https://github.com/singer-io/tap-linkedin-ads/pull/48)
+  * Added missing fields in the schemas and upgraded API version [#47](https://github.com/singer-io/tap-linkedin-ads/pull/47)
+  * Add missing tap tester [#46](https://github.com/singer-io/tap-linkedin-ads/pull/46)
+  * Add backoff error handling for 5xx [#45](https://github.com/singer-io/tap-linkedin-ads/pull/45)
+  * Remove version pins for dev requirements [#38](https://github.com/singer-io/tap-linkedin-ads/pull/38)
+  * Rewrite access_token into the config to reuse in the next sync if it is updated [#52](https://github.com/singer-io/tap-linkedin-ads/pull/52)
+
 ## 1.2.7
   * Checks Access Token expiration before attempting to refresh token.
   * Adds backoff case for token expiration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## 1.3.0
   * Dictionary based to class based implementation [#48](https://github.com/singer-io/tap-linkedin-ads/pull/48)
   * Added missing fields in the schemas and upgraded API version [#47](https://github.com/singer-io/tap-linkedin-ads/pull/47)
-  * Add missing tap tester [#46](https://github.com/singer-io/tap-linkedin-ads/pull/46)
   * Add backoff error handling for 5xx [#45](https://github.com/singer-io/tap-linkedin-ads/pull/45)
   * Remove version pins for dev requirements [#38](https://github.com/singer-io/tap-linkedin-ads/pull/38)
   * Rewrite access_token into the config to reuse in the next sync if it is updated [#52](https://github.com/singer-io/tap-linkedin-ads/pull/52)
+  * Add missing tap tester [#46](https://github.com/singer-io/tap-linkedin-ads/pull/46)
 
 ## 1.2.7
   * Checks Access Token expiration before attempting to refresh token.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='1.2.7',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Minor Bump version with the following changelog - 
  * Dictionary based to class-based implementation [#48](https://github.com/singer-io/tap-linkedin-ads/pull/48)
  * Added missing fields in the schemas and upgraded API version [#47](https://github.com/singer-io/tap-linkedin-ads/pull/47)
  * Add missing tap tester [#46](https://github.com/singer-io/tap-linkedin-ads/pull/46)
  * Add backoff error handling for 5xx [#45](https://github.com/singer-io/tap-linkedin-ads/pull/45)
  * Remove version pins for dev requirements [#38](https://github.com/singer-io/tap-linkedin-ads/pull/38)
  * Rewrite access_token into the config to reuse in the next sync if it is updated [#52](https://github.com/singer-io/tap-linkedin-ads/pull/52)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
