### PR TITLE
Upgrade creatives api endpoint 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .DEFAULT_GOAL := lint
 
 lint:
-	pylint tap_linkedin_ads -d 'broad-except,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,too-many-locals,invalid-name,consider-using-f-string,use-list-literal,use-dict-literal,raise-missing-from, unspecified-encoding'
+	pylint tap_linkedin_ads -d 'broad-except,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,too-many-locals,invalid-name,consider-using-f-string,use-list-literal,use-dict-literal,raise-missing-from, unspecified-encoding, broad-exception-raised'

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ This tap:
 - Replication strategy: Incremental (query all, filter results)
   - Filter: campaign_id (from parent campaign)
   - Sort by: Creative id ascending
-  - Bookmark: last_modified_time (date-time)
-- Transformations: Fields camelCase to snake_case. URNs to ids. Unix epoch millisecond integers to date-times. Audit date-times created_at and last_modified_at de-nested. Variables are transformed to a generalized type with list of key/value pairs.
+  - Bookmark: last_modified_at (date-time)
+- Transformations: Fields camelCase to snake_case. URNs to ids. Unix epoch millisecond integers to date-times.
 - Parent: campaign
 
 [**ad_analytics_by_campaign**](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting#analytics-finder)

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ This tap:
 - Transformations: Fields camelCase to snake_case. URNs to ids. Unix epoch millisecond integers to date-times. Audit date-times created_at and last_modified_at de-nested. String to decimal for daily_budget and unit_cost amount fields. Targeting and Targeting Criteria are transformed to a generalized type with list array structure.
 - Children: creatives, ad_analytics_by_campaign, ad_analytics_by_creative
 
-[**creatives**](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives#search-for-creatives)
-- Endpoint: https://api.linkedin.com/rest/adCreatives
+[**creatives**](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2023-01&tabs=http#search-for-creatives)
+- Endpoint: https://api.linkedin.com/rest/creatives
 - Primary key field: id
 - Foreign keys: campaign_id (campaigns)
 - Replication strategy: Incremental (query all, filter results)

--- a/tap_linkedin_ads/schemas/creatives.json
+++ b/tap_linkedin_ads/schemas/creatives.json
@@ -41,6 +41,33 @@
             "null",
             "string"
           ]
+        },
+        "text_ad": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "headline": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "description": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "landing_page": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
         }
       }
     },
@@ -82,29 +109,29 @@
         "string"
       ]
     },
-    "is_serving":{
+    "is_serving": {
       "type": [
         "null",
         "boolean"
       ]
     },
-    "is_test":{
+    "is_test": {
       "type": [
         "null",
         "boolean"
       ]
     },
     "serving_hold_reasons": {
-          "type": [
-            "null",
-            "array"
-          ],
-          "items": {
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        }
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    }
   }
 }

--- a/tap_linkedin_ads/schemas/creatives.json
+++ b/tap_linkedin_ads/schemas/creatives.json
@@ -5,6 +5,18 @@
   ],
   "additionalProperties": false,
   "properties": {
+    "account": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
     "campaign": {
       "type": [
         "null",
@@ -17,99 +29,72 @@
         "integer"
       ]
     },
-    "change_audit_stamps": {
+    "content": {
       "type": [
         "null",
         "object"
       ],
       "additionalProperties": false,
       "properties": {
-        "created": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "time": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "date-time"
-            }
-          }
-        },
-        "last_modified": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "time": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "date-time"
-            }
-          }
-        }
-      }
-    },
-    "created_time": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
-    "last_modified_time": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
-    "id": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
-    "processing_state": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "reference": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "reference_share_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
-    "review": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "review_status": {
+        "reference": {
           "type": [
             "null",
             "string"
           ]
-        },
-        "rejection_reason": {
+        }
+      }
+    },
+    "created_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "created_by": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "last_modified_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_by": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "intended_status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "is_serving":{
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "is_test":{
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "serving_hold_reasons": {
           "type": [
             "null",
             "array"
@@ -121,104 +106,5 @@
             ]
           }
         }
-      }
-    },
-    "status": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "type": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "variables": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "click_uri": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "type": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "values": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": [
-                  "null",
-                  "object"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "key": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  }
-                }
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "test": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
-    "serving_statuses": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "type": [
-          "null",
-          "string"
-        ]
-      }
-    },
-    "version": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "version_tag": {
-          "type": [
-            "null",
-            "string"
-          ]
-        }
-      }
-    }
   }
 }

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -645,13 +645,13 @@ class Campaigns(LinkedInAds):
 
 class Creatives(LinkedInAds):
     """
-    https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives#search-for-creatives
+    https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2023-01&tabs=http#search-for-creatives
     """
     tap_stream_id = "creatives"
     replication_method = "INCREMENTAL"
-    replication_keys = ["last_modified_time"]
+    replication_keys = ["last_modified_at"]
     key_properties = ["id"]
-    path = "adCreatives"
+    path = "creatives"
     foreign_key = "id"
     data_key = "elements"
     parent = "campaigns"

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -104,6 +104,10 @@ def get_next_url(data):
         if rel == 'next':
             href = link.get('href')
             if href:
+                # url must be kept encoded for the creatives endpoint.
+                # Ref - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2023-01&tabs=http#sample-request-3
+                if "rest/creatives" in href:
+                    return 'https://api.linkedin.com{}'.format(href)
                 # Prepare next page URL
                 next_url = 'https://api.linkedin.com{}'.format(urllib.parse.unquote(href))
     return next_url
@@ -186,7 +190,7 @@ class LinkedInAds:
     children = []
     count = None
     params = {}
-
+    headers = {}
     def write_schema(self, catalog):
         """
         Write the schema for the selected stream.
@@ -329,7 +333,8 @@ class LinkedInAds:
             # Get data, API request
             data = client.get(
                 url=next_url,
-                endpoint=self.tap_stream_id)
+                endpoint=self.tap_stream_id,
+                headers=self.headers)
             # time_extracted: datetime when the data was extracted from the API
             time_extracted = utils.now()
 
@@ -385,7 +390,9 @@ class LinkedInAds:
                         elif self.tap_stream_id == 'campaigns':
                             campaign = 'urn:li:sponsoredCampaign:{}'.format(parent_id)
                             if child_stream_name == 'creatives':
-                                child_stream_params['search.campaign.values[0]'] = campaign
+                                # The value of the campaigns in the query params should be passed in the encoded format.
+                                # Ref - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2023-01&tabs=http#sample-request-3
+                                child_stream_params['campaigns'] = 'List(urn%3Ali%3AsponsoredCampaign%3A{})'.format(parent_id)
                             elif child_stream_name in ('ad_analytics_by_campaign', 'ad_analytics_by_creative'):
                                 child_stream_params['campaigns[0]'] = campaign
 
@@ -655,12 +662,17 @@ class Creatives(LinkedInAds):
     foreign_key = "id"
     data_key = "elements"
     parent = "campaigns"
+    # The value of the campaigns in the query params should be passed in the encoded format.
+    # Ref - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2023-01&tabs=http#sample-request-3
     params = {
-        "q": "search",
-        "search.campaign.values[0]": "urn:li:sponsoredCampaign:{}",
-        "sort.field": "ID",
-        "sort.order": "ASCENDING"
+        "q": "criteria",
+        "campaigns": "List(urn%3Ali%3AsponsoredCampaign%3A{})",
+        "sortOrder": "ASCENDING"
     }
+    # Requires this specific headers for creatives endpoint.
+    # Ref - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2023-01&tabs=http#search-for-creatives
+    headers = {'X-Restli-Protocol-Version': "2.0.0",
+               "X-RestLi-Method": "FINDER"}
 
 class AdAnalyticsByCampaign(LinkedInAds):
     """

--- a/tests/base.py
+++ b/tests/base.py
@@ -115,7 +115,7 @@ class TestLinkedinAdsBase(unittest.TestCase):
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.OBEYS_START_DATE: True,
-                self.REPLICATION_KEYS: {'last_modified_time'}
+                self.REPLICATION_KEYS: {'last_modified_at'}
             },
             'ad_analytics_by_campaign': {
                 self.PRIMARY_KEYS: {'campaign_id', 'start_at'},


### PR DESCRIPTION
# Description of change
The endpoint **_v2/adCreativesV2_** is sunsetting and getting replaced with **_rest/creatives_**. Ref - [Marketing API Versioning](https://learn.microsoft.com/en-us/linkedin/marketing/versioning?view=li-lms-2022-07)
This PR adds the correct endpoint for the _creatives_ stream. Ref - [Creatives API](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2023-01&tabs=http#search-for-creatives)

Few things to keep in mind - 
1. It requires the query parameter - **campaigns** to be passed in encoded format.
2. Specific headers are required - 
```
{"X-Restli-Protocol-Version": "2.0.0",
 "X-RestLi-Method": "FINDER"}
```
Jira - [TDL-21780](https://jira.talendforge.org/browse/TDL-21780)

# Manual QA steps
 - Tested data replication on dev-vm.
 - Performed alpha for the internal client.
 
# Risks
 - Minimal risk, as this is going to be the major bump version.
 
# Rollback steps
 - revert this branch
