### PR TITLE
Tdl 22339 Use query tunneling to allow large number of accounts

### DIFF
--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -18,9 +18,11 @@ REQUEST_TIMEOUT = 300
 class LinkedInError(Exception):
     pass
 
-class Server5xxError(LinkedInError):
+class TooManyAccountsError(LinkedInError):
     pass
 
+class Server5xxError(LinkedInError):
+    pass
 
 class Server429Error(LinkedInError):
     pass
@@ -35,7 +37,6 @@ class LinkedInUnauthorizedError(LinkedInError):
 
 class LinkedInMethodNotAllowedError(LinkedInError):
     pass
-
 
 class LinkedInNotFoundError(LinkedInError):
     pass
@@ -84,6 +85,10 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     429: {
         "raise_exception": LinkedInRateLimitExceeededError,
         "message": "API rate limit exceeded, please retry after some time."
+    },
+    431: {
+        "raise_exception": TooManyAccountsError,
+        "message": "The number of accounts exceeds the size limit of the request."
     },
     500: {
         "raise_exception": LinkedInInternalServiceError,

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -367,8 +367,9 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
         # Use query tunneling to allow large URIs
         # https://learn.microsoft.com/en-us/linkedin/shared/api-guide/concepts/query-tunneling?context=linkedin/context
         if method == 'GET':
-            url, query = url.split('?', 1)
-            kwargs['data'] = query
+            if url:
+                url, query = url.split('?', 1)
+                kwargs['data'] = query
             kwargs['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
             kwargs['headers']['X-HTTP-Method-Override'] = 'GET'
 


### PR DESCRIPTION
# Description of change
A large number of accounts will cause the API to error because the  request URI is too long. This PR adds query tunneling to allow larger URIs and clients to enter many accounts 
https://learn.microsoft.com/en-us/linkedin/shared/api-guide/concepts/query-tunneling?context=linkedin/context

# Manual QA steps
 - pr alphad with `Tdl 22339` client, and resolved the error they were receiving. 
 
# Risks
 - low - the tap should function the same, this just changes the way a request is sent. However, we never got feedback from `Tdl 22339`, just saw that there error was resolved and they were able to sync. 
 
# Rollback steps
 - revert this branch
