### PR TITLE
TDL-22682 Update API version and FIELDS_UNACCEPTED_BY_API

### DIFF
--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -11,6 +11,7 @@ LOGGER = singer.get_logger()
 BASE_URL = 'https://api.linkedin.com/rest'
 LINKEDIN_TOKEN_URI = 'https://www.linkedin.com/oauth/v2/accessToken'
 INTROSPECTION_URI = 'https://www.linkedin.com/oauth/v2/introspectToken'
+LINKEDIN_VERSION = '202302'
 
 # set default timeout of 300 seconds
 REQUEST_TIMEOUT = 300
@@ -293,7 +294,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
             headers['User-Agent'] = self.__user_agent
         headers['Authorization'] = 'Bearer {}'.format(self.__access_token)
         headers['Accept'] = 'application/json'
-        headers['LinkedIn-Version'] = "202207"
+        headers['LinkedIn-Version'] = LINKEDIN_VERSION
 
         if config.get('accounts'):
             account_list = config['accounts'].replace(" ", "").split(",")
@@ -348,7 +349,7 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
             kwargs['headers'] = {}
         kwargs['headers']['Authorization'] = 'Bearer {}'.format(self.__access_token)
         kwargs['headers']['Accept'] = 'application/json'
-        kwargs['headers']['LinkedIn-Version'] = "202207"
+        kwargs['headers']['LinkedIn-Version'] = LINKEDIN_VERSION
         kwargs['headers']['Cache-Control'] = "no-cache"
 
         if self.__user_agent:

--- a/tap_linkedin_ads/schema.py
+++ b/tap_linkedin_ads/schema.py
@@ -6,6 +6,15 @@ from tap_linkedin_ads.streams import STREAMS
 # Reference:
 #   https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#Metadata
 
+# The following fields of ads_analytics (...by_campaign and ...by_creative) were previously in beta and are not available on
+# API version 202302. Requesting them results in a 403.
+# https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2023-02&tabs=http#accuracy
+FIELDS_UNACCEPTED_BY_API = {
+    "average_daily_reach_metrics",
+    "average_previous_seven_day_reach_metrics",
+    "average_previous_thirty_day_reach_metrics",
+}
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
@@ -17,6 +26,11 @@ def get_schemas():
         schema_path = get_abs_path('schemas/{}.json'.format(stream_name))
         with open(schema_path, encoding='utf-8') as file:
             schema = json.load(file)
+
+            if stream_name in ('ad_analytics_by_campaign', 'ad_analytics_by_creative'):
+                for field in FIELDS_UNACCEPTED_BY_API:
+                    metadata.delete(schema, 'properties', field)
+
         schemas[stream_name] = schema
         mdata = metadata.new()
 

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -18,24 +18,7 @@ FIELDS_UNAVAILABLE_FOR_AD_ANALYTICS = {
     'startAt',
     'endAt',
     'creative',
-    'creativeId'
-}
-
-# As mentioned here some fields of ads_analytics are currently in beta:
-# https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2022-08&tabs=http#accuracy
-FIELDS_UNACCEPTED_BY_API = {
-    "ad_analytics_by_creative": {
-        "averageDailyReachMetrics",
-        "averagePreviousSevenDayReachMetrics",
-        "averagePreviousThirtyDayReachMetrics",
-        "approximateUniqueImpressions"
-    },
-    "ad_analytics_by_campaign": {
-        "averageDailyReachMetrics",
-        "averagePreviousSevenDayReachMetrics",
-        "averagePreviousThirtyDayReachMetrics",
-        "approximateUniqueImpressions"
-    }
+    'creativeId',
 }
 
 def write_bookmark(state, value, stream_name):
@@ -488,8 +471,7 @@ class LinkedInAds:
         # API accepts these fields in the parameter and returns its value in the response.
         valid_selected_fields = [snake_case_to_camel_case(field)
                                  for field in selected_fields(catalog.get_stream(self.tap_stream_id))
-                                 if snake_case_to_camel_case(field) not in FIELDS_UNAVAILABLE_FOR_AD_ANALYTICS.union(
-                                     FIELDS_UNACCEPTED_BY_API.get(self.tap_stream_id, set()))]
+                                 if snake_case_to_camel_case(field) not in FIELDS_UNAVAILABLE_FOR_AD_ANALYTICS]
 
         # When testing the API, if the fields in `field` all return `0` then
         # the API returns its empty response.


### PR DESCRIPTION
# Description of change
- Updates the API version to support fields previously considered beta by Microsoft.
- LINKEDIN_VERSION global added to ensure consistent versioning throughout client.py
- Moves FIELDS_UNACCEPTED_BY_API to remove filtered fields from field selection
- Updates FIELDS_UNACCEPTED_BY_API to allow for replication of approximate_unique_impressions

# Manual QA steps
 - Tested with local connection
 
# Risks
 - Minimal; version bump is now set via global for ease of use
 
# Rollback steps
 - revert this branch
