### PR TITLE
upgrade API version to 202304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.0
+  * Bump to API version `202304`
+
 ## 2.1.0
   * Bump to API version `202302`
   * Move and update `FIELDS_UNACCEPTED_BY_API`

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='2.1.0',
+      version='2.2.0',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -11,7 +11,7 @@ LOGGER = singer.get_logger()
 BASE_URL = 'https://api.linkedin.com/rest'
 LINKEDIN_TOKEN_URI = 'https://www.linkedin.com/oauth/v2/accessToken'
 INTROSPECTION_URI = 'https://www.linkedin.com/oauth/v2/introspectToken'
-LINKEDIN_VERSION = '202302'
+LINKEDIN_VERSION = '202304'
 
 # set default timeout of 300 seconds
 REQUEST_TIMEOUT = 300


### PR DESCRIPTION
# Description of change
The current API version - 202302 is deprecated. Upgrading it to the API version 202304.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
