### PR TITLE
Upgrade api version 202403 video ads

### DIFF
--- a/tap_linkedin_ads/schemas/video_ads.json
+++ b/tap_linkedin_ads/schemas/video_ads.json
@@ -11,6 +11,186 @@
         "string"
       ]
     },
+    "lifecycle_state": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "visibility": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "published_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "author": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_call_to_action_label": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "distribution": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "feed_distribution": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "third_party_distribution_channels": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "content": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "media": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "title": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "content_landing_page": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "lifecycle_state_info": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "is_edited_by_author": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        }
+      }
+    },
+    "is_reshare_disabled_by_author": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "created_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "commentary": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_context": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "dsc_status": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "dsc_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "dsc_ad_type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "is_dsc": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "dsc_ad_account": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
     "account_id": {
       "type": [
         "null",

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -618,6 +618,17 @@ class VideoAds(LinkedInAds):
     }
     headers = {'X-Restli-Protocol-Version': "2.0.0"}
 
+    def sync_endpoint(self, *args, **kwargs):
+        try:
+            return super().sync_endpoint(*args, **kwargs)
+        except Exception as error:
+            if "Not enough permissions to access: partnerApiPostsExternal" in str(error):
+                LOGGER.warning("Access to the video-ads API is denied due to insufficient permissions. Please reauthenticate or verify the required permissions.")
+                LOGGER.error("Error: %s", error)
+                return 0, self.get_bookmark(kwargs.get("state"), kwargs.get("start_date"))
+            else:
+                raise error
+
 class AccountUsers(LinkedInAds):
     """
     https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-account-users#find-ad-account-users-by-accounts

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -97,7 +97,6 @@ def get_next_url(stream_name, next_url, data):
                 next_url = f"{next_url}&pageToken={next_page_token}"
         else:
             next_url = None
-        return next_url
     else:
         next_url = None
         links = data.get('paging', {}).get('links', [])
@@ -112,7 +111,7 @@ def get_next_url(stream_name, next_url, data):
                         return 'https://api.linkedin.com{}'.format(href)
                     # Prepare next page URL
                     next_url = 'https://api.linkedin.com{}'.format(urllib.parse.unquote(href))
-        return next_url
+    return next_url
 
 def shift_sync_window(params, today, date_window_size, forced_window_size=None):
     """
@@ -130,7 +129,6 @@ def shift_sync_window(params, today, date_window_size, forced_window_size=None):
                   'dateRange.start.day': current_end.day,
                   'dateRange.start.month': current_end.month,
                   'dateRange.start.year': current_end.year,
-
                   'dateRange.end.day': new_end.day,
                   'dateRange.end.month': new_end.month,
                   'dateRange.end.year': new_end.year,}
@@ -279,7 +277,7 @@ class LinkedInAds:
 
             return max_bookmark_value, counter.value
 
-    # pylint: disable=too-many-branches,too-many-statements,too-many-arguments,too-many-locals
+    # pylint: disable=too-many-branches,too-many-statements,too-many-arguments,too-many-locals,too-many-nested-blocks
     def sync_endpoint(self,
                       client,
                       catalog,
@@ -406,8 +404,6 @@ class LinkedInAds:
                             # Add children filter params based on parent IDs
                             if self.tap_stream_id == 'accounts':
                                 account = 'urn:li:sponsoredAccount:{}'.format(parent_id)
-                                owner_id = record.get('reference_organization_id', None)
-                                owner = 'urn:li:organization:{}'.format(owner_id)
                             elif self.tap_stream_id == 'campaigns':
                                 campaign = 'urn:li:sponsoredCampaign:{}'.format(parent_id)
                                 if child_stream_name == 'creatives':

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -623,8 +623,9 @@ class VideoAds(LinkedInAds):
             return super().sync_endpoint(*args, **kwargs)
         except Exception as error:
             if "Not enough permissions to access: partnerApiPostsExternal" in str(error):
-                LOGGER.warning("Access to the video-ads API is denied due to insufficient permissions. Please reauthenticate or verify the required permissions.")
-                LOGGER.error("Error: %s", error)
+                LOGGER.info("Access to the video-ads API is denied due to insufficient permissions. Please reauthenticate or verify the required permissions.")
+                LOGGER.error(error)
+                # total record count (zero), initial bookmark returned to supress this failure
                 return 0, self.get_bookmark(kwargs.get("state"), kwargs.get("start_date"))
             else:
                 raise error

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -92,9 +92,9 @@ def get_next_url(stream_name, next_url, data):
         next_page_token = data.get('metadata', {}).get('nextPageToken', None)
         if next_page_token:
             if 'pageToken=' in next_url:
-                next_url = re.sub(r'pageToken=[^&]+', f'pageToken={next_page_token}', next_url)
+                next_url = re.sub(r'pageToken=[^&]+', 'pageToken={}'.format(next_page_token), next_url)
             else:
-                next_url = f"{next_url}&pageToken={next_page_token}"
+                next_url = next_url + "&pageToken={}".format(next_page_token)
         else:
             next_url = None
     else:
@@ -342,7 +342,7 @@ class LinkedInAds:
         urllist = []
         if self.tap_stream_id in NEW_PATH_STREAMS:
             for account in account_list:
-                url = f"{BASE_URL}/adAccounts/{account}/{self.path}?{querystring}"
+                url = "{}/adAccounts/{}/{}?{}".format(BASE_URL, account, self.path, querystring)
                 urllist.append((account, url))
         else:
             if self.path == 'posts':
@@ -627,8 +627,7 @@ class VideoAds(LinkedInAds):
                 LOGGER.error(error)
                 # total record count (zero), initial bookmark returned to supress this failure
                 return 0, self.get_bookmark(kwargs.get("state"), kwargs.get("start_date"))
-            else:
-                raise error
+            raise error
 
 class AccountUsers(LinkedInAds):
     """

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -129,7 +129,7 @@ def sync(client, config, catalog, state):
             stream_obj.write_schema(catalog)
 
         total_records, max_bookmark_value = stream_obj.sync_endpoint(
-            client=client, catalog=catalog, 
+            client=client, catalog=catalog,
             state=state, page_size=page_size,
             start_date=start_date,
             selected_streams=selected_streams,

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -109,15 +109,14 @@ def sync(client, config, catalog, state):
                 params = stream_obj.params
                 if account_filter == 'search_id_values_param':
                     # Convert account IDs to URN format
-                    urn_list = [f"urn%3Ali%3AsponsoredAccount%3A{account_id}" for account_id in account_list]
+                    urn_list = ["urn%3Ali%3AsponsoredAccount%3A{}".format(account_id) for account_id in account_list]
                     # Create the query parameter string
-                    param_value = f"(id:(values:List({','.join(urn_list)})))"
+                    param_value = "(id:(values:List({})))".format(','.join(urn_list))
                     params['search'] = param_value
                 elif account_filter == 'accounts_param':
                     for idx, account in enumerate(account_list):
                         params['accounts[{}]'.format(idx)] = \
                             'urn:li:sponsoredAccount:{}'.format(account)
-
                 # Update params of specific stream
                 stream_obj.params = params
 

--- a/tap_linkedin_ads/transform.py
+++ b/tap_linkedin_ads/transform.py
@@ -295,6 +295,7 @@ def transform_urn(data_dict):
 
 
 def transform_video_ads(data_dict):
+    # pylint: disable=fixme
     # TODO: To be removed in next major version release
     if 'author' in data_dict:
         data_dict['owner'] = data_dict["author"]

--- a/tap_linkedin_ads/transform.py
+++ b/tap_linkedin_ads/transform.py
@@ -294,6 +294,24 @@ def transform_urn(data_dict):
     return data_dict
 
 
+def transform_video_ads(data_dict):
+    # TODO: To be removed in next major version release
+    if 'author' in data_dict:
+        data_dict['owner'] = data_dict["author"]
+    if 'id' in data_dict:
+        data_dict['content_reference'] = data_dict["id"]
+    if 'ad_context' in data_dict:
+        if 'dsc_name' in data_dict['ad_context']:
+            data_dict['name'] = data_dict["ad_context"]['dsc_name']
+        if 'dsc_ad_type' in data_dict['ad_context']:
+            data_dict['type'] = data_dict["ad_context"]['dsc_ad_type']
+        if 'dsc_ad_account' in data_dict['ad_context']:
+            data_dict['account'] = data_dict["ad_context"]['dsc_ad_account']
+    if 'last_modified_at' in data_dict:
+        data_dict['last_modified_time'] = data_dict["last_modified_at"]
+    if 'created_at' in data_dict:
+        data_dict['created_time'] = data_dict["created_at"]
+    return data_dict
 
 def transform_data(data_dict, stream_name):
     new_dict = data_dict
@@ -308,6 +326,8 @@ def transform_data(data_dict, stream_name):
             this_dict = transform_campaigns(this_dict)
         elif stream_name == 'creatives':
             this_dict = transform_creatives(this_dict)
+        elif stream_name == 'video_ads':
+            this_dict = transform_video_ads(this_dict)
         this_dict = transform_urn(this_dict)
         this_dict = transform_audit_fields(this_dict)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -81,7 +81,7 @@ class TestLinkedinAdsBase(unittest.TestCase):
     def expected_check_streams():
         return {
             'accounts',
-            # 'video_ads',
+            'video_ads',
             'account_users',
             'campaign_groups',
             'campaigns',
@@ -100,12 +100,12 @@ class TestLinkedinAdsBase(unittest.TestCase):
                 self.OBEYS_START_DATE: True,
                 self.REPLICATION_KEYS: {'last_modified_time'}
             },
-            # 'video_ads': {
-            #     self.PRIMARY_KEYS: {'content_reference'},
-            #     self.REPLICATION_METHOD: self.INCREMENTAL,
-            #     self.OBEYS_START_DATE: True,
-            #     self.REPLICATION_KEYS: {'last_modified_time'}
-            # },
+            'video_ads': {
+                self.PRIMARY_KEYS: {'content_reference'},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.OBEYS_START_DATE: True,
+                self.REPLICATION_KEYS: {'last_modified_time'}
+            },
             'account_users': {
                 self.PRIMARY_KEYS: {'account_id', 'user_person_id'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -22,6 +22,7 @@ KNOWN_MISSING_FIELDS = {
     "video_ads": {
         "content_reference_share_id",
         "content_reference_ucg_post_id",
+        "change_audit_stamps"
     },
     "accounts": {
         "total_budget_ends_at",

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -70,7 +70,7 @@ class TestStreamsUtils(unittest.TestCase):
     """
     Test all utility functions of streams module
     """
-    
+
     def test_split_into_chunks(self):
         """
         Test that `test_split_into_chunks` split 65 fields into 4 chunk of MAX_CHUNK_LENGTH
@@ -126,11 +126,11 @@ class TestStreamsUtils(unittest.TestCase):
         mock_next_url.side_effect = next_url
         client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')     
         data = list(sync_analytics_endpoint(client, "stream", "path", "query=query"))
-        
+
         # Verify that get method of client is called expected times.
         self.assertEqual(expected_call_count, mock_get.call_count)
-        
-        
+
+
     @parameterized.expand([
         ["test_single_page", [], None],
         ["test_multiple_page", [{'rel': 'next', 'href': '/foo'}], 'https://api.linkedin.com/foo']
@@ -168,13 +168,13 @@ class TestStreamsUtils(unittest.TestCase):
             'dateRange.end.month': expected_end_date.month,
             'dateRange.end.day': expected_end_date.day,
         }
-        
+
         params = {
             'dateRange.end.year': 2020,
             'dateRange.end.month': 10,
             'dateRange.end.day': 1,
         }
-        
+
         today = datetime.date(year=2020, month=today_month, day=today_date)
 
         actual_start_date, actual_end_date, actual_params = shift_sync_window(params, today, 30)
@@ -282,11 +282,11 @@ class TestLinkedInAds(unittest.TestCase):
         Case 3: Return default value if stream_name is not found in the bookmarks
         Cas 4: Return actual bookmark value if it is found in the state
         """
-        
+
         actual_output = ACCOUNT_OBJ.get_bookmark(state, "default")
-        
+
         self.assertEqual(expected_output, actual_output)
-        
+
     @parameterized.expand([
         ['test_zero_records', ACCOUNT_OBJ, [], "last_modified_time", "2021-07-20T08:50:30.169000Z", 0],
         ['test_zero_latest_records', ACCOUNT_OBJ, [{'id': 1, 'last_modified_time': '2021-06-26T08:50:30.169000Z'}], "last_modified_time", "2021-07-20T08:50:30.169000Z", 0],
@@ -300,7 +300,7 @@ class TestLinkedInAds(unittest.TestCase):
         """
         max_bookmark_value = last_datetime = "2021-07-20T08:50:30.169000Z"
         actual_max_bookmark, actual_record_count = stream_obj.process_records(CATALOG, records, utils.now(), replication_key, max_bookmark_value, last_datetime)
-        
+
         # Verify maximum bookmark and total records.
         self.assertEqual(expected_max_bookmark, actual_max_bookmark)
         self.assertEqual(expected_record_count, actual_record_count)
@@ -323,7 +323,7 @@ class TestLinkedInAds(unittest.TestCase):
         ['test_only_parent_selcted_stream', ['campaigns'], CAMPAIGN_OBJ,
          [{'paging': {'start': 0, 'count': 100, 'links': [], 'total': 1},'elements': [{'changeAuditStamps': {'created': {'time': 1564585620000}, 'lastModified': {'time': 1564585620000}}, 'id': 1}]}],
          0, 1
-        ]   
+        ]
     ])
     @mock.patch("tap_linkedin_ads.streams.LinkedInAds.sync_ad_analytics", return_value=(1, "2019-07-31T15:07:00.000000Z"))
     @mock.patch("tap_linkedin_ads.streams.LinkedInAds.get_bookmark", return_value = "2019-07-31T15:07:00.000000Z")
@@ -344,7 +344,7 @@ class TestLinkedInAds(unittest.TestCase):
         mock_client.side_effect = mock_response
         mock_process_records.return_value = "2019-07-31T15:07:00.000000Z",1
         actual_total_record, actual_max_bookmark = stream_obj.sync_endpoint(client, CATALOG, state, page_size, start_date, selected_streams, date_window_size)
-        
+
         # Verify total no of records
         self.assertEqual(actual_total_record, mock_record_count)
         # Verify maximum bookmark
@@ -352,28 +352,6 @@ class TestLinkedInAds(unittest.TestCase):
         # Verify total no of write_schema function call. sync_endpoint calls write_schema single time for each child.
         self.assertEqual(mock_write_schema.call_count, expected_write_schema_count)
 
-    @mock.patch("tap_linkedin_ads.sync.LOGGER.warning")
-    @mock.patch("tap_linkedin_ads.streams.LinkedInAds.get_bookmark", return_value = "2019-07-31T15:07:00.000000Z")
-    @mock.patch("tap_linkedin_ads.client.LinkedinClient.request")
-    @mock.patch("tap_linkedin_ads.streams.LinkedInAds.process_records")
-    @mock.patch("tap_linkedin_ads.streams.LinkedInAds.write_schema")
-    def test_sync_endpoint_for_reference_organization_id_is_None(self, mock_write_schema,mock_process_records,mock_client,mock_get_bookmark,
-                                                                 mock_warning):
-        """
-        Verify that tap skips API call for video_ads stream if owner_id in the parent's record is None.
-        """
-        client = LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
-        state={'currently_syncing': 'accounts'}
-        start_date='2019-06-01T00:00:00Z'
-        page_size = 100
-        date_window_size = 7
-        selected_streams = ['accounts', 'video_ads']
-
-        mock_client.side_effect = [{'paging': {'start': 0, 'count': 100, 'links': [], 'total': 1},'elements': [{'changeAuditStamps': {'created': {'time': 1564585620000}, 'lastModified': {'time': 1564585620000}}, 'id': 1}]}]
-        mock_process_records.return_value = "2019-07-31T15:07:00.000000Z",1
-        ACCOUNT_OBJ.sync_endpoint(client, CATALOG, state, page_size, start_date, selected_streams, date_window_size)
-        
-        mock_warning.assert_called_with('Skipping video_ads call for %s account as reference_organization_id is not found.', 'urn:li:sponsoredAccount:1')
 
 
     @parameterized.expand([
@@ -398,7 +376,7 @@ class TestLinkedInAds(unittest.TestCase):
         mock_transform.return_value = mock_tranform_data
         mock_process_record.return_value = (expected_max_bookmark, expected_record_count)
         actual_record_count, actual_max_bookmark =  AD_ANALYTICS_BY_CAMPAIGN.sync_ad_analytics(client, CATALOG, bookmark, date_window_size)
-        
+
         # Verify maximum bookmark
         self.assertEqual(actual_max_bookmark, expected_max_bookmark)
         # Verify total no of records
@@ -423,5 +401,5 @@ class TestLinkedInAds(unittest.TestCase):
         """
         with self.assertRaises(OSError) as e:
             ACCOUNT_OBJ.write_record([], '')
-        
+
         mock_logger.assert_called_with('record: %s', [])


### PR DESCRIPTION
# Important
## This adds a temporary transformation for the `video_ads` stream to make it compatible with the current api version as the stream implementation and endpoint has changed (changing the replication & primary keys), hence preventing the need to do a major version release for the current api deprecation deadline.

## Description of change
- Removed deprecated endpoint `adDirectSponsoredContents`
- Implement `posts` search endpoint, [Documentation](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2024-03&tabs=curl#find-posts-by-account)
- Add new schema fields
- Map new keys to existing field keys

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
