### PR TITLE
Display warning for refresh_token expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.0
+  * Display warning message to reauthorize the connection if the refresh token is going to expire within the next month. ([#77](https://github.com/singer-io/tap-linkedin-ads/pull/77))
+
 ## 2.4.0
   * Bump to API version `202501` ([#76](https://github.com/singer-io/tap-linkedin-ads/pull/76))
   * Fixes Dependabot issue

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='2.4.0',
+      version='2.5.0',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -3,113 +3,158 @@ import tap_linkedin_ads.client as _client
 import tap_linkedin_ads
 import unittest
 import requests
-from datetime import datetime
+from datetime import datetime, timedelta
 import calendar
 
 @mock.patch("tap_linkedin_ads.client.LinkedinClient.write_access_token_to_config")
 @mock.patch("requests.Session.post")
 class TestLinkedInClient(unittest.TestCase):
 
-    def test_access_token_empty_expires(self, mocked_post, mock_write_token):
+    # def test_access_token_empty_expires(self, mocked_post, mock_write_token):
+    #     '''
+    #     Ensure that we retrieve and set expires for client with no self.__expires
+    #     '''
+    #     client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
+
+    #     future_time = int(datetime.utcnow().timestamp()) + 88400
+    #     mocked_response = mock.Mock()
+    #     mocked_response.json.return_value = {
+    #         "expires_at": future_time,
+    #         "created_at": 1716560216
+    #     }
+        
+    #     mocked_response.status_code = 200
+    #     mocked_post.return_value = mocked_response
+
+    #     expires = client.get_expires_time_for_test()
+    #     assert expires is None
+
+    #     client.fetch_and_set_access_token()
+    #     expires = client.get_expires_time_for_test()
+
+    #     self.assertEqual(expires, datetime.fromtimestamp(future_time))
+
+    # def test_access_token_expires_valid(self, mocked_post, mock_write_token):
+    #     '''
+    #     Ensure that we check and return on valid self.__expires
+    #     '''
+    #     client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
+
+    #     future_time = int(datetime.utcnow().timestamp()) + 88400
+    #     mocked_response = mock.MagicMock()
+    #     mocked_response.status_code = 200
+    #     mocked_response.json.return_value = {
+    #         "access_token": "abcdef12345",
+    #         "expires_at": future_time,
+    #         "created_at": 1716560216
+    #     }
+    #     mocked_post.return_value = mocked_response
+
+    #     client.set_mock_expires_for_test(datetime.fromtimestamp(future_time))
+    #     client.fetch_and_set_access_token()
+    #     expires = client.get_expires_time_for_test()
+    #     self.assertEqual(expires, datetime.fromtimestamp(future_time))
+
+
+    # def test_access_token_expires_invalid(self, mocked_post, mock_write_token):
+    #     '''
+    #     Ensure that we check self.__expires and retrieve new access token if it has expired
+    #     '''
+    #     client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
+
+    #     old_time = int(datetime.utcnow().timestamp()) - 100
+    #     mocked_response = mock.MagicMock()
+    #     mocked_response.status_code = 200
+    #     mocked_response.json.return_value = {
+    #         "access_token": "abcdef12345",
+    #         "expires_in": 5184000,
+    #         "created_at": 1716560216
+    #     }
+    #     mocked_post.return_value = mocked_response
+
+    #     client.set_mock_expires_for_test(datetime.fromtimestamp(old_time))
+    #     client.fetch_and_set_access_token()
+    #     new_expires = client.get_expires_time_for_test()
+    #     self.assertGreater(new_expires, datetime.fromtimestamp(old_time))
+
+    # def test_no_access_token(self, mocked_post, mock_write_token):
+    #     '''
+    #     Ensure that we get an access token if we don't already have one
+    #     '''
+    #     client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'config_path', None)
+
+    #     expires = client.get_expires_time_for_test()
+    #     assert expires is None
+
+    #     old_time = int(datetime.utcnow().timestamp()) - 100
+    #     mocked_token_check_response = mock.Mock()
+    #     mocked_token_check_response.json.return_value = {
+    #         "access_token": "abcdef12345",
+    #         "expires_at": old_time,
+    #         "created_at": 1716560216
+    #     }
+    #     mocked_token_check_response.status_code = 200
+
+    #     mocked_refresh_token_response = mock.Mock()
+    #     mocked_refresh_token_response.json.return_value = {
+    #         "access_token": "abcdef12345",
+    #         "expires_in": 5184000,
+    #         "created_at": 1716560216
+    #     }
+    #     mocked_refresh_token_response.status_code = 200
+    #     mocked_post.side_effect = [mocked_token_check_response, mocked_refresh_token_response]
+
+    #     client.fetch_and_set_access_token()
+    #     expires = client.get_expires_time_for_test()
+    #     self.assertGreater(expires, datetime.fromtimestamp(old_time))
+
+    # def test_no_refresh_token(self, mocked_post, mock_write_token):
+    #     '''
+    #     Ensure that we use the existing access token if we don't have a refresh token
+    #     '''
+    #     expected_access_token = 'access_token'
+    #     client = _client.LinkedinClient(None, None, None, 'access_token', 'config_path')
+
+    #     client.fetch_and_set_access_token()
+    #     actual = client.access_token
+    #     self.assertEqual(expected_access_token, actual)
+
+    @mock.patch("tap_linkedin_ads.client.LOGGER")
+    def test_refresh_token_expires_within_month(self, mock_logger, mocked_post, mock_write_token):
         '''
-        Ensure that we retrieve and set expires for client with no self.__expires
+        Ensure that we log a warning if the refresh token expires within a month
         '''
         client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
 
-        future_time = int(datetime.utcnow().timestamp()) + 88400
         mocked_response = mock.Mock()
         mocked_response.json.return_value = {
-            "expires_at": future_time
+            "expires_at": datetime.utcnow().timestamp(),
+            "created_at": (datetime.utcnow() - timedelta(days=334)).timestamp()
         }
         
         mocked_response.status_code = 200
         mocked_post.return_value = mocked_response
 
-        expires = client.get_expires_time_for_test()
-        assert expires is None
+        client.get_token_expires()
+        mock_logger.warning.assert_called_with(
+            "The refresh token is going to expire soon. Please re-authenticate your connection to generate a new token and resume extraction."
+        )
 
-        client.fetch_and_set_access_token()
-        expires = client.get_expires_time_for_test()
-
-        self.assertEqual(expires, datetime.fromtimestamp(future_time))
-
-    def test_access_token_expires_valid(self, mocked_post, mock_write_token):
+    @mock.patch("tap_linkedin_ads.client.LOGGER")
+    def test_refresh_token_empty_expires_after_2_month(self, mock_logger, mocked_post, mock_write_token):
         '''
-        Ensure that we check and return on valid self.__expires
+        Ensure that we do not log a warning if the refresh token expires after 2 months
         '''
         client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
 
-        future_time = int(datetime.utcnow().timestamp()) + 88400
-        mocked_response = mock.MagicMock()
-        mocked_response.status_code = 200
+        mocked_response = mock.Mock()
         mocked_response.json.return_value = {
-            "access_token": "abcdef12345",
-            "expires_at": future_time,
+            "expires_at": datetime.utcnow().timestamp(),
+            "created_at": (datetime.utcnow() - timedelta(days=304)).timestamp()
         }
+
+        mocked_response.status_code = 200
         mocked_post.return_value = mocked_response
 
-        client.set_mock_expires_for_test(datetime.fromtimestamp(future_time))
-        client.fetch_and_set_access_token()
-        expires = client.get_expires_time_for_test()
-        self.assertEqual(expires, datetime.fromtimestamp(future_time))
-
-
-    def test_access_token_expires_invalid(self, mocked_post, mock_write_token):
-        '''
-        Ensure that we check self.__expires and retrieve new access token if it has expired
-        '''
-        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
-
-        old_time = int(datetime.utcnow().timestamp()) - 100
-        mocked_response = mock.MagicMock()
-        mocked_response.status_code = 200
-        mocked_response.json.return_value = {
-            "access_token": "abcdef12345",
-            "expires_in": 5184000
-        }
-        mocked_post.return_value = mocked_response
-
-        client.set_mock_expires_for_test(datetime.fromtimestamp(old_time))
-        client.fetch_and_set_access_token()
-        new_expires = client.get_expires_time_for_test()
-        self.assertGreater(new_expires, datetime.fromtimestamp(old_time))
-
-    def test_no_access_token(self, mocked_post, mock_write_token):
-        '''
-        Ensure that we get an access token if we don't already have one
-        '''
-        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'config_path', None)
-
-        expires = client.get_expires_time_for_test()
-        assert expires is None
-
-        old_time = int(datetime.utcnow().timestamp()) - 100
-        mocked_token_check_response = mock.Mock()
-        mocked_token_check_response.json.return_value = {
-            "access_token": "abcdef12345",
-            "expires_at": old_time
-        }
-        mocked_token_check_response.status_code = 200
-
-        mocked_refresh_token_response = mock.Mock()
-        mocked_refresh_token_response.json.return_value = {
-            "access_token": "abcdef12345",
-            "expires_in": 5184000
-        }
-        mocked_refresh_token_response.status_code = 200
-        mocked_post.side_effect = [mocked_token_check_response, mocked_refresh_token_response]
-
-        client.fetch_and_set_access_token()
-        expires = client.get_expires_time_for_test()
-        self.assertGreater(expires, datetime.fromtimestamp(old_time))
-
-    def test_no_refresh_token(self, mocked_post, mock_write_token):
-        '''
-        Ensure that we use the existing access token if we don't have a refresh token
-        '''
-        expected_access_token = 'access_token'
-        client = _client.LinkedinClient(None, None, None, 'access_token', 'config_path')
-
-        client.fetch_and_set_access_token()
-        actual = client.access_token
-        self.assertEqual(expected_access_token, actual)
+        client.get_token_expires()
+        self.assertEqual(mock_logger.warning.call_count, 0)

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -10,114 +10,114 @@ import calendar
 @mock.patch("requests.Session.post")
 class TestLinkedInClient(unittest.TestCase):
 
-    # def test_access_token_empty_expires(self, mocked_post, mock_write_token):
-    #     '''
-    #     Ensure that we retrieve and set expires for client with no self.__expires
-    #     '''
-    #     client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
+    def test_access_token_empty_expires(self, mocked_post, mock_write_token):
+        '''
+        Ensure that we retrieve and set expires for client with no self.__expires
+        '''
+        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
 
-    #     future_time = int(datetime.utcnow().timestamp()) + 88400
-    #     mocked_response = mock.Mock()
-    #     mocked_response.json.return_value = {
-    #         "expires_at": future_time,
-    #         "created_at": 1716560216
-    #     }
+        future_time = int(datetime.utcnow().timestamp()) + 88400
+        mocked_response = mock.Mock()
+        mocked_response.json.return_value = {
+            "expires_at": future_time,
+            "created_at": 1716560216
+        }
         
-    #     mocked_response.status_code = 200
-    #     mocked_post.return_value = mocked_response
+        mocked_response.status_code = 200
+        mocked_post.return_value = mocked_response
 
-    #     expires = client.get_expires_time_for_test()
-    #     assert expires is None
+        expires = client.get_expires_time_for_test()
+        assert expires is None
 
-    #     client.fetch_and_set_access_token()
-    #     expires = client.get_expires_time_for_test()
+        client.fetch_and_set_access_token()
+        expires = client.get_expires_time_for_test()
 
-    #     self.assertEqual(expires, datetime.fromtimestamp(future_time))
+        self.assertEqual(expires, datetime.fromtimestamp(future_time))
 
-    # def test_access_token_expires_valid(self, mocked_post, mock_write_token):
-    #     '''
-    #     Ensure that we check and return on valid self.__expires
-    #     '''
-    #     client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
+    def test_access_token_expires_valid(self, mocked_post, mock_write_token):
+        '''
+        Ensure that we check and return on valid self.__expires
+        '''
+        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
 
-    #     future_time = int(datetime.utcnow().timestamp()) + 88400
-    #     mocked_response = mock.MagicMock()
-    #     mocked_response.status_code = 200
-    #     mocked_response.json.return_value = {
-    #         "access_token": "abcdef12345",
-    #         "expires_at": future_time,
-    #         "created_at": 1716560216
-    #     }
-    #     mocked_post.return_value = mocked_response
+        future_time = int(datetime.utcnow().timestamp()) + 88400
+        mocked_response = mock.MagicMock()
+        mocked_response.status_code = 200
+        mocked_response.json.return_value = {
+            "access_token": "abcdef12345",
+            "expires_at": future_time,
+            "created_at": 1716560216
+        }
+        mocked_post.return_value = mocked_response
 
-    #     client.set_mock_expires_for_test(datetime.fromtimestamp(future_time))
-    #     client.fetch_and_set_access_token()
-    #     expires = client.get_expires_time_for_test()
-    #     self.assertEqual(expires, datetime.fromtimestamp(future_time))
+        client.set_mock_expires_for_test(datetime.fromtimestamp(future_time))
+        client.fetch_and_set_access_token()
+        expires = client.get_expires_time_for_test()
+        self.assertEqual(expires, datetime.fromtimestamp(future_time))
 
 
-    # def test_access_token_expires_invalid(self, mocked_post, mock_write_token):
-    #     '''
-    #     Ensure that we check self.__expires and retrieve new access token if it has expired
-    #     '''
-    #     client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
+    def test_access_token_expires_invalid(self, mocked_post, mock_write_token):
+        '''
+        Ensure that we check self.__expires and retrieve new access token if it has expired
+        '''
+        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
 
-    #     old_time = int(datetime.utcnow().timestamp()) - 100
-    #     mocked_response = mock.MagicMock()
-    #     mocked_response.status_code = 200
-    #     mocked_response.json.return_value = {
-    #         "access_token": "abcdef12345",
-    #         "expires_in": 5184000,
-    #         "created_at": 1716560216
-    #     }
-    #     mocked_post.return_value = mocked_response
+        old_time = int(datetime.utcnow().timestamp()) - 100
+        mocked_response = mock.MagicMock()
+        mocked_response.status_code = 200
+        mocked_response.json.return_value = {
+            "access_token": "abcdef12345",
+            "expires_in": 5184000,
+            "created_at": 1716560216
+        }
+        mocked_post.return_value = mocked_response
 
-    #     client.set_mock_expires_for_test(datetime.fromtimestamp(old_time))
-    #     client.fetch_and_set_access_token()
-    #     new_expires = client.get_expires_time_for_test()
-    #     self.assertGreater(new_expires, datetime.fromtimestamp(old_time))
+        client.set_mock_expires_for_test(datetime.fromtimestamp(old_time))
+        client.fetch_and_set_access_token()
+        new_expires = client.get_expires_time_for_test()
+        self.assertGreater(new_expires, datetime.fromtimestamp(old_time))
 
-    # def test_no_access_token(self, mocked_post, mock_write_token):
-    #     '''
-    #     Ensure that we get an access token if we don't already have one
-    #     '''
-    #     client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'config_path', None)
+    def test_no_access_token(self, mocked_post, mock_write_token):
+        '''
+        Ensure that we get an access token if we don't already have one
+        '''
+        client = _client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'config_path', None)
 
-    #     expires = client.get_expires_time_for_test()
-    #     assert expires is None
+        expires = client.get_expires_time_for_test()
+        assert expires is None
 
-    #     old_time = int(datetime.utcnow().timestamp()) - 100
-    #     mocked_token_check_response = mock.Mock()
-    #     mocked_token_check_response.json.return_value = {
-    #         "access_token": "abcdef12345",
-    #         "expires_at": old_time,
-    #         "created_at": 1716560216
-    #     }
-    #     mocked_token_check_response.status_code = 200
+        old_time = int(datetime.utcnow().timestamp()) - 100
+        mocked_token_check_response = mock.Mock()
+        mocked_token_check_response.json.return_value = {
+            "access_token": "abcdef12345",
+            "expires_at": old_time,
+            "created_at": 1716560216
+        }
+        mocked_token_check_response.status_code = 200
 
-    #     mocked_refresh_token_response = mock.Mock()
-    #     mocked_refresh_token_response.json.return_value = {
-    #         "access_token": "abcdef12345",
-    #         "expires_in": 5184000,
-    #         "created_at": 1716560216
-    #     }
-    #     mocked_refresh_token_response.status_code = 200
-    #     mocked_post.side_effect = [mocked_token_check_response, mocked_refresh_token_response]
+        mocked_refresh_token_response = mock.Mock()
+        mocked_refresh_token_response.json.return_value = {
+            "access_token": "abcdef12345",
+            "expires_in": 5184000,
+            "created_at": 1716560216
+        }
+        mocked_refresh_token_response.status_code = 200
+        mocked_post.side_effect = [mocked_token_check_response, mocked_refresh_token_response]
 
-    #     client.fetch_and_set_access_token()
-    #     expires = client.get_expires_time_for_test()
-    #     self.assertGreater(expires, datetime.fromtimestamp(old_time))
+        client.fetch_and_set_access_token()
+        expires = client.get_expires_time_for_test()
+        self.assertGreater(expires, datetime.fromtimestamp(old_time))
 
-    # def test_no_refresh_token(self, mocked_post, mock_write_token):
-    #     '''
-    #     Ensure that we use the existing access token if we don't have a refresh token
-    #     '''
-    #     expected_access_token = 'access_token'
-    #     client = _client.LinkedinClient(None, None, None, 'access_token', 'config_path')
+    def test_no_refresh_token(self, mocked_post, mock_write_token):
+        '''
+        Ensure that we use the existing access token if we don't have a refresh token
+        '''
+        expected_access_token = 'access_token'
+        client = _client.LinkedinClient(None, None, None, 'access_token', 'config_path')
 
-    #     client.fetch_and_set_access_token()
-    #     actual = client.access_token
-    #     self.assertEqual(expected_access_token, actual)
+        client.fetch_and_set_access_token()
+        actual = client.access_token
+        self.assertEqual(expected_access_token, actual)
 
     @mock.patch("tap_linkedin_ads.client.LOGGER")
     def test_refresh_token_expires_within_month(self, mock_logger, mocked_post, mock_write_token):


### PR DESCRIPTION
# Description of change
- Display a warning message to reauthorize the connection if the refresh token is going to expire within the next month. 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
