### PR TITLE
SAC-28853: Add `parent-tap-stream-id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.6.0
+  * Adds `parent_tap_stream_id` as discoverable metadata
+  * Add latest versions for dependencies
+  * [#82](https://github.com/singer-io/tap-linkedin-ads/pull/82)
+
 ## 2.5.0
   * Bump to API version `202511`
   * Add missing fields into schemas

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='2.5.0',
+      version='2.6.0',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_linkedin_ads'],
       install_requires=[
           'backoff==2.2.1',
-          'requests==2.32.4',
-          'singer-python==6.1.0'
+          'requests==2.32.5',
+          'singer-python==6.3.0'
       ],
       extras_require={
         'dev': [

--- a/tap_linkedin_ads/schema.py
+++ b/tap_linkedin_ads/schema.py
@@ -55,6 +55,8 @@ def get_schemas():
         for replication_key in stream_metadata.replication_keys:
             mdata_map[('properties', replication_key)]['inclusion'] = 'automatic'
 
+        if stream_metadata.parent:
+            mdata_map = metadata.write(mdata_map, (), "parent-tap-stream-id", stream_metadata.parent)
         mdata = metadata.to_list(mdata_map)
 
         field_metadata[stream_name] = mdata


### PR DESCRIPTION
# Description of change
This PR writes `parent-tap-stream-id` to the catalog

# Manual QA steps
 - I ran discovery before and after the change. Here's the diff

<img width="848" height="755" alt="CleanShot 2025-10-03 at 14 32 06@2x" src="https://github.com/user-attachments/assets/4033b6db-174e-4868-ae20-f0a31d0b4d8b" />

 
# Risks
 - Low. This is new-to-this-tap metadata so nothing should break because of this.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
