### PR TITLE
Upgrade api version to 202511

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.0
+  * Bumpe to API version `202511`
+  * Add missing fields into schemas
+
 ## 2.4.1
   * Bump dependency versions for twistlock compliance
   * Update tests to fix failing circle build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.5.0
-  * Bumpe to API version `202511`
+  * Bump to API version `202511`
   * Add missing fields into schemas
 
 ## 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.5.0
   * Bump to API version `202511`
   * Add missing fields into schemas
+  * Display warning message to reauthorize the connection if the refresh token is going to expire within the next month. ([#77](https://github.com/singer-io/tap-linkedin-ads/pull/77))
 
 ## 2.4.1
   * Bump dependency versions for twistlock compliance

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='2.4.1',
+      version='2.5.0',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -11,7 +11,7 @@ LOGGER = singer.get_logger()
 BASE_URL = 'https://api.linkedin.com/rest'
 LINKEDIN_TOKEN_URI = 'https://www.linkedin.com/oauth/v2/accessToken'
 INTROSPECTION_URI = 'https://www.linkedin.com/oauth/v2/introspectToken'
-LINKEDIN_VERSION = '202501'
+LINKEDIN_VERSION = '202511'
 
 # set default timeout of 300 seconds
 REQUEST_TIMEOUT = 300

--- a/tap_linkedin_ads/schemas/campaigns.json
+++ b/tap_linkedin_ads/schemas/campaigns.json
@@ -229,6 +229,24 @@
         "string"
       ]
     },
+    "story_delivery_enabled": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "connected_television_only": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "political_intent": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "total_budget": {
       "type": [
         "null",

--- a/tap_linkedin_ads/schemas/creatives.json
+++ b/tap_linkedin_ads/schemas/creatives.json
@@ -11,6 +11,27 @@
         "string"
       ]
     },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "review": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
     "account_id": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change
Upgrade api version to 202511. Add missing fields into schems.
Display warning message to reauthorize the connection if the refresh token is going to expire within the next month. ([#77](https://github.com/singer-io/tap-linkedin-ads/pull/77))

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
