### PR TITLE
Exclude 403-inaccessible streams from catalog during discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.7.0
+  * Exclude 403-inaccessible streams from catalog during discovery [#86](https://github.com/singer-io/tap-linkedin-ads/pull/86)
+  * Added `accounts` as a required config field
+  * Added unit tests for discovery access-check logic
+  * Bump requests version to 2.34.2 and singer-python to 6.8.0
+
 ## 2.6.1
   * Bump requests version to 2.33.0 [#85](https://github.com/singer-io/tap-linkedin-ads/pull/85)
 

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='2.6.1',
+      version='2.7.0',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_linkedin_ads'],
       install_requires=[
           'backoff==2.2.1',
-          'requests==2.33.0',
-          'singer-python==6.3.0'
+          'requests==2.34.2',
+          'singer-python==6.8.0'
       ],
       extras_require={
         'dev': [

--- a/tap_linkedin_ads/__init__.py
+++ b/tap_linkedin_ads/__init__.py
@@ -15,14 +15,16 @@ REQUEST_TIMEOUT = 300
 
 REQUIRED_CONFIG_KEYS = [
     'access_token',
-    'user_agent'
+    'user_agent',
+    'accounts'
 ]
 
 
 def do_discover(client, config):
     LOGGER.info('Starting discover')
     client.check_accounts(config)
-    catalog = _discover()
+    client.config = config
+    catalog = _discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
 

--- a/tap_linkedin_ads/discover.py
+++ b/tap_linkedin_ads/discover.py
@@ -1,8 +1,69 @@
+import singer
+from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_linkedin_ads.schema import get_schemas, STREAMS
+from tap_linkedin_ads.client import LinkedInForbiddenError
 
-def discover():
+LOGGER = singer.get_logger()
+
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name, stream_cls.parent,
+            )
+            schemas.pop(name)
+            field_metadata.pop(name)
+
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from schemas and field_metadata in place.
+    Note: check_access() always returns True for child streams, so this loop
+    effectively identifies only inaccessible parent streams by design.
+    Child stream removal is handled separately by _prune_inaccessible_children().
+    Raises LinkedInForbiddenError if no parent streams are accessible.
+    """
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_obj in STREAMS.items()
+        if stream_name in schemas and not stream_obj().check_access(client)
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if not schemas:
+        raise LinkedInForbiddenError(
+            "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+            "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+        )
+    if inaccessible_streams:
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+            "These streams have been excluded from the catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def discover(client) -> Catalog:
+    """
+    Run the discovery mode, prepare the catalog file and return the catalog.
+    Access to each stream is verified using the provided client and streams
+    the credentials cannot read are excluded from the returned catalog.
+    """
     schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():

--- a/tap_linkedin_ads/discover.py
+++ b/tap_linkedin_ads/discover.py
@@ -36,7 +36,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     """
     inaccessible_streams = []
 
-    # --- Pass 1: check parent streams and collect first real IDs ---
+    # Pass 1: check parent streams and collect first real IDs
     parent_first_ids = {}  # stream_name -> first record ID (str) or None
     for stream_name, stream_cls in list(STREAMS.items()):
         if stream_name not in schemas:
@@ -60,7 +60,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     # Prune children whose parent was just excluded before the child pass.
     _prune_inaccessible_children(schemas, field_metadata)
 
-    # --- Pass 2: check child streams using real parent IDs ---
+    # Pass 2: check child streams using real parent IDs
     for stream_name, stream_cls in list(STREAMS.items()):
         if stream_name not in schemas:
             continue

--- a/tap_linkedin_ads/discover.py
+++ b/tap_linkedin_ads/discover.py
@@ -25,22 +25,53 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     """
     Probe each stream for read access and remove inaccessible streams
     (and their children) from schemas and field_metadata in place.
-    Both parent and child streams are individually probed via check_access().
-    Child streams whose parent was also excluded are additionally pruned by
-    _prune_inaccessible_children().
-    Raises LinkedInForbiddenError if no streams are accessible.
+
+    Two-pass strategy:
+      Pass 1 — parent streams: check access, fetch first real record ID.
+      Pass 2 — child streams: probe using the real parent ID.
+        - Parent excluded → child pruned before pass 2.
+        - Parent has no records → child included with a warning, no probe.
+
+    Raises LinkedInForbiddenError if no streams remain accessible.
     """
-    inaccessible_streams = [
-        stream_name
-        for stream_name, stream_obj in STREAMS.items()
-        if stream_name in schemas and not stream_obj().check_access(client)
-    ]
+    inaccessible_streams = []
 
-    for stream_name in inaccessible_streams:
-        schemas.pop(stream_name, None)
-        field_metadata.pop(stream_name, None)
+    # --- Pass 1: check parent streams and collect first real IDs ---
+    parent_first_ids = {}  # stream_name -> first record ID (str) or None
+    for stream_name, stream_cls in list(STREAMS.items()):
+        if stream_name not in schemas:
+            continue
+        if stream_cls.parent:
+            continue  # handled in pass 2
+        stream_obj = stream_cls()
+        if stream_obj.check_access(client):
+            parent_first_ids[stream_name] = stream_obj.get_first_id(client)
+            if parent_first_ids[stream_name] is None:
+                LOGGER.info(
+                    "Stream '%s' is accessible but returned no records; child streams "
+                    "will be included without an API access probe.",
+                    stream_name,
+                )
+        else:
+            inaccessible_streams.append(stream_name)
+            schemas.pop(stream_name, None)
+            field_metadata.pop(stream_name, None)
 
+    # Prune children whose parent was just excluded before the child pass.
     _prune_inaccessible_children(schemas, field_metadata)
+
+    # --- Pass 2: check child streams using real parent IDs ---
+    for stream_name, stream_cls in list(STREAMS.items()):
+        if stream_name not in schemas:
+            continue
+        if not stream_cls.parent:
+            continue  # already handled
+        real_parent_id = parent_first_ids.get(stream_cls.parent)
+        stream_obj = stream_cls()
+        if not stream_obj.check_access(client, parent_id=real_parent_id):
+            inaccessible_streams.append(stream_name)
+            schemas.pop(stream_name, None)
+            field_metadata.pop(stream_name, None)
 
     if not schemas:
         raise LinkedInForbiddenError(

--- a/tap_linkedin_ads/discover.py
+++ b/tap_linkedin_ads/discover.py
@@ -1,5 +1,4 @@
 import singer
-from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_linkedin_ads.schema import get_schemas, STREAMS
 from tap_linkedin_ads.client import LinkedInForbiddenError
@@ -18,18 +17,18 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
                 "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
                 name, stream_cls.parent,
             )
-            schemas.pop(name)
-            field_metadata.pop(name)
+            schemas.pop(name, None)
+            field_metadata.pop(name, None)
 
 
 def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     """
     Probe each stream for read access and remove inaccessible streams
     (and their children) from schemas and field_metadata in place.
-    Note: check_access() always returns True for child streams, so this loop
-    effectively identifies only inaccessible parent streams by design.
-    Child stream removal is handled separately by _prune_inaccessible_children().
-    Raises LinkedInForbiddenError if no parent streams are accessible.
+    Both parent and child streams are individually probed via check_access().
+    Child streams whose parent was also excluded are additionally pruned by
+    _prune_inaccessible_children().
+    Raises LinkedInForbiddenError if no streams are accessible.
     """
     inaccessible_streams = [
         stream_name
@@ -45,13 +44,12 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
 
     if not schemas:
         raise LinkedInForbiddenError(
-            "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
-            "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            "HTTP-error-code: 403, Error: The credentials do not have "
+            "'read' access to any supported streams."
         )
     if inaccessible_streams:
         LOGGER.warning(
-            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
-            "These streams have been excluded from the catalog.",
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
             ", ".join(inaccessible_streams),
         )
 

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -8,7 +8,7 @@ from singer import metrics, metadata, utils
 from singer import Transformer, should_sync_field, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
 from singer.utils import strptime_to_utc, strftime
 from tap_linkedin_ads.transform import transform_json, snake_case_to_camel_case
-from tap_linkedin_ads.client import LinkedInForbiddenError
+from tap_linkedin_ads.client import LinkedInForbiddenError, LinkedInBadRequestError, LinkedInNotFoundError
 
 LOGGER = singer.get_logger()
 
@@ -201,22 +201,42 @@ class LinkedInAds:
         """
         Verify that the API credentials have read access to this stream.
         Returns True if accessible, False if a 403 Forbidden error is raised.
-        Child streams always return True (access is governed by the parent check).
-        This means children are never flagged by the access-check loop in _apply_access_checks();
-        their removal from the catalog is handled separately by _prune_inaccessible_children().
+        All streams — including child streams — are individually probed.
+        Non-403 errors (e.g. 400, 404) are treated as accessible because they indicate
+        the endpoint is reachable; the probe params may not be perfect for child streams
+        (e.g. no real parent ID available at discovery time), but only a 403 confirms
+        the credentials lack access.
         """
         LOGGER.info("Checking access for stream: %s", self.tap_stream_id)
-        if self.parent:
-            return True
-
         config = getattr(client, 'config', {})
         account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
 
+        if not account_list:
+            raise ValueError(
+                "Configuration error: 'accounts' must contain at least one valid account ID."
+            )
+
         try:
             if self.tap_stream_id in NEW_PATH_STREAMS:
-                url = "{}/adAccounts/{}/{}?q=search&pageSize=1".format(
-                    BASE_URL, account_list[0], self.path
-                )
+                if self.parent:
+                    # Child stream in NEW_PATH_STREAMS (e.g. creatives): can't use q=search.
+                    # Build the probe using the stream's own params, substituting a dummy
+                    # value (0) for any parent ID placeholders ({}).
+                    probe_params = {
+                        k: v.format(0) if isinstance(v, str) and '{}' in v else v
+                        for k, v in self.params.items()
+                    }
+                    probe_params['pageSize'] = 1
+                    querystring = '&'.join(
+                        ['{}={}'.format(k, v) for k, v in probe_params.items()]
+                    )
+                    url = '{}/adAccounts/{}/{}?{}'.format(
+                        BASE_URL, account_list[0], self.path, querystring
+                    )
+                else:
+                    url = '{}/adAccounts/{}/{}?q=search&pageSize=1'.format(
+                        BASE_URL, account_list[0], self.path
+                    )
             else:
                 probe_params = dict(self.params)
                 probe_params['count'] = 1
@@ -234,14 +254,23 @@ class LinkedInAds:
                 )
                 url = '{}/{}?{}'.format(BASE_URL, self.path, querystring)
 
-            client.get(url=url, endpoint=self.tap_stream_id, headers=self.headers)
+            client.get(url=url, endpoint=self.tap_stream_id, headers=dict(self.headers))
             return True
-        except LinkedInForbiddenError:
+        except LinkedInForbiddenError as exc:
             LOGGER.warning(
-                "Stream '%s' does not have read permission (403), excluding from catalog.",
+                "Permission Error: Stream '%s' %s. Excluding from catalog.",
                 self.__class__.__name__,
+                exc,
             )
             return False
+        except (LinkedInBadRequestError, LinkedInNotFoundError) as exc:
+            # Dummy parent ID caused a 400/404 — endpoint is reachable, credentials are fine.
+            LOGGER.info(
+                "Stream '%s': probe returned a non-403 error (%s) — endpoint reachable.",
+                self.tap_stream_id,
+                exc,
+            )
+            return True
 
     def write_schema(self, catalog):
         """
@@ -669,6 +698,42 @@ class VideoAds(LinkedInAds):
         "count":100
     }
     headers = {'X-Restli-Protocol-Version': "2.0.0"}
+
+    def check_access(self, client):
+        """
+        Override check_access for video_ads because its path is 'posts', which requires
+        a dscAdAccount query param to get a meaningful response rather than a 400.
+        """
+        LOGGER.info("Checking access for stream: %s", self.tap_stream_id)
+        config = getattr(client, 'config', {})
+        account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
+
+        if not account_list:
+            raise ValueError(
+                "Configuration error: 'accounts' must contain at least one valid account ID."
+            )
+
+        url = '{}/{}?q=dscAdAccount&dscAdTypes=List(VIDEO)&count=1&dscAdAccount=urn%3Ali%3AsponsoredAccount%3A{}'.format(
+            BASE_URL, self.path, account_list[0]
+        )
+        try:
+            client.get(url=url, endpoint=self.tap_stream_id, headers=dict(self.headers))
+            return True
+        except LinkedInForbiddenError as exc:
+            LOGGER.warning(
+                "Permission Error: Stream '%s' %s. Excluding from catalog.",
+                self.__class__.__name__,
+                exc,
+            )
+            return False
+        except (LinkedInBadRequestError, LinkedInNotFoundError) as exc:
+            # Dummy parent ID caused a 400/404 — endpoint is reachable, credentials are fine.
+            LOGGER.info(
+                "Stream '%s': probe returned a non-403 error (%s) — endpoint reachable.",
+                self.tap_stream_id,
+                exc,
+            )
+            return True
 
     def sync_endpoint(self, *args, **kwargs):
         try:

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -8,7 +8,7 @@ from singer import metrics, metadata, utils
 from singer import Transformer, should_sync_field, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
 from singer.utils import strptime_to_utc, strftime
 from tap_linkedin_ads.transform import transform_json, snake_case_to_camel_case
-from tap_linkedin_ads.client import LinkedInForbiddenError, LinkedInBadRequestError, LinkedInNotFoundError
+from tap_linkedin_ads.client import LinkedInForbiddenError
 
 LOGGER = singer.get_logger()
 
@@ -29,6 +29,16 @@ FIELDS_UNAVAILABLE_FOR_AD_ANALYTICS = {
 CURSOR_BASED_PAGINATION_STREAMS = ["accounts", "campaign_groups", "campaigns", "creatives"]
 NEW_PATH_STREAMS = ["campaign_groups", "campaigns", "creatives"]
 BASE_URL = 'https://api.linkedin.com/rest'
+
+# adAnalytics requires dateRange — shared static 1-day probe window for both analytics streams.
+_AD_ANALYTICS_PROBE_DATE_RANGE = {
+    'dateRange.start.day': 1,
+    'dateRange.start.month': 1,
+    'dateRange.start.year': 2024,
+    'dateRange.end.day': 1,
+    'dateRange.end.month': 1,
+    'dateRange.end.year': 2024,
+}
 
 def write_bookmark(state, value, stream_name):
     """
@@ -196,16 +206,68 @@ class LinkedInAds:
     count = None
     params = {}
     headers = {}
+    # Extra params merged into the access probe request only.
+    # Subclasses that require mandatory query params (e.g. dateRange for
+    # adAnalytics) can define these without overriding check_access.
+    access_probe_extra_params = {}
 
-    def check_access(self, client):
+    def _build_probe_url(self, account_list, parent_id=None):
         """
-        Verify that the API credentials have read access to this stream.
-        Returns True if accessible, False if a 403 Forbidden error is raised.
-        All streams — including child streams — are individually probed.
-        Non-403 errors (e.g. 400, 404) are treated as accessible because they indicate
-        the endpoint is reachable; the probe params may not be perfect for child streams
-        (e.g. no real parent ID available at discovery time), but only a 403 confirms
-        the credentials lack access.
+        Build the probe URL used by both check_access and get_first_id.
+        parent_id is only used for child streams in NEW_PATH_STREAMS.
+        """
+        if self.tap_stream_id in NEW_PATH_STREAMS:
+            if self.parent and parent_id:
+                probe_params = {
+                    k: v.format(parent_id) if isinstance(v, str) and '{}' in v else v
+                    for k, v in self.params.items()
+                }
+                probe_params['pageSize'] = 1
+                querystring = '&'.join(['{}={}'.format(k, v) for k, v in probe_params.items()])
+                return '{}/adAccounts/{}/{}?{}'.format(BASE_URL, account_list[0], self.path, querystring)
+            return '{}/adAccounts/{}/{}?q=search&pageSize=1'.format(BASE_URL, account_list[0], self.path)
+
+        probe_params = dict(self.params)
+        probe_params['count'] = 1
+        if self.account_filter == 'search_id_values_param':
+            urn_list = ["urn%3Ali%3AsponsoredAccount%3A{}".format(a) for a in account_list]
+            probe_params['search'] = "(id:(values:List({})))".format(','.join(urn_list))
+        elif self.account_filter == 'accounts_param':
+            probe_params['accounts[0]'] = 'urn:li:sponsoredAccount:{}'.format(account_list[0])
+        probe_params.update(self.access_probe_extra_params)
+        querystring = '&'.join(['{}={}'.format(k, v) for k, v in probe_params.items()])
+        return '{}/{}?{}'.format(BASE_URL, self.path, querystring)
+
+    def get_first_id(self, client):
+        """
+        Fetch the first real record ID from this stream's API endpoint.
+        Returns the numeric ID as a string, or None if no records or on any error.
+        Used so child streams can be probed with a real parent ID at discovery time.
+        """
+        config = getattr(client, 'config', {})
+        account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
+        if not account_list:
+            return None
+        try:
+            url = self._build_probe_url(account_list)
+            data = client.get(url=url, endpoint=self.tap_stream_id, headers=dict(self.headers))
+            elements = data.get(self.data_key, [])
+            if elements:
+                raw_id = str(elements[0].get('id', ''))
+                # LinkedIn IDs may be URNs (e.g. "urn:li:sponsoredCampaign:12345");
+                # extract the numeric portion for safe URL embedding.
+                return raw_id.rsplit(':', 1)[-1] if ':' in raw_id else raw_id
+            return None
+        except Exception:  # pylint: disable=broad-except
+            return None
+
+    def check_access(self, client, parent_id=None):
+        """
+        Verify read access to this stream. Returns True if accessible, False on 403.
+
+        For child streams: probe uses the supplied parent_id for an accurate result.
+        If parent_id is None (parent had no records), skips the probe and includes
+        the stream with a warning to avoid a false negative from an invalid URL.
         """
         LOGGER.info("Checking access for stream: %s", self.tap_stream_id)
         config = getattr(client, 'config', {})
@@ -216,61 +278,26 @@ class LinkedInAds:
                 "Configuration error: 'accounts' must contain at least one valid account ID."
             )
 
-        try:
-            if self.tap_stream_id in NEW_PATH_STREAMS:
-                if self.parent:
-                    # Child stream in NEW_PATH_STREAMS (e.g. creatives): can't use q=search.
-                    # Build the probe using the stream's own params, substituting a dummy
-                    # value (0) for any parent ID placeholders ({}).
-                    probe_params = {
-                        k: v.format(0) if isinstance(v, str) and '{}' in v else v
-                        for k, v in self.params.items()
-                    }
-                    probe_params['pageSize'] = 1
-                    querystring = '&'.join(
-                        ['{}={}'.format(k, v) for k, v in probe_params.items()]
-                    )
-                    url = '{}/adAccounts/{}/{}?{}'.format(
-                        BASE_URL, account_list[0], self.path, querystring
-                    )
-                else:
-                    url = '{}/adAccounts/{}/{}?q=search&pageSize=1'.format(
-                        BASE_URL, account_list[0], self.path
-                    )
-            else:
-                probe_params = dict(self.params)
-                probe_params['count'] = 1
-                if self.account_filter == 'search_id_values_param' and account_list:
-                    urn_list = [
-                        "urn%3Ali%3AsponsoredAccount%3A{}".format(a) for a in account_list
-                    ]
-                    probe_params['search'] = "(id:(values:List({})))".format(','.join(urn_list))
-                elif self.account_filter == 'accounts_param' and account_list:
-                    probe_params['accounts[0]'] = 'urn:li:sponsoredAccount:{}'.format(
-                        account_list[0]
-                    )
-                querystring = '&'.join(
-                    ['{}={}'.format(k, v) for k, v in probe_params.items()]
-                )
-                url = '{}/{}?{}'.format(BASE_URL, self.path, querystring)
+        # Child stream with no available parent record — skip probe with a warning.
+        if self.parent and parent_id is None:
+            LOGGER.warning(
+                "Stream '%s': parent stream '%s' returned no records so no real "
+                "parent ID is available for the access probe. Including '%s' in "
+                "the catalog without an API check.",
+                self.tap_stream_id, self.parent, self.tap_stream_id,
+            )
+            return True
 
+        try:
+            url = self._build_probe_url(account_list, parent_id=parent_id)
             client.get(url=url, endpoint=self.tap_stream_id, headers=dict(self.headers))
             return True
         except LinkedInForbiddenError as exc:
             LOGGER.warning(
                 "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message: '%s'",
-                self.tap_stream_id,
-                str(exc),
+                self.tap_stream_id, str(exc),
             )
             return False
-        except (LinkedInBadRequestError, LinkedInNotFoundError) as exc:
-            # Dummy parent ID caused a 400/404 — endpoint is reachable, credentials are fine.
-            LOGGER.info(
-                "Stream '%s': probe returned a non-403 error (%s) — endpoint reachable.",
-                self.tap_stream_id,
-                exc,
-            )
-            return True
 
     def write_schema(self, catalog):
         """
@@ -699,10 +726,11 @@ class VideoAds(LinkedInAds):
     }
     headers = {'X-Restli-Protocol-Version': "2.0.0"}
 
-    def check_access(self, client):
+    def check_access(self, client, parent_id=None):
         """
         Override check_access for video_ads because its path is 'posts', which requires
         a dscAdAccount query param to get a meaningful response rather than a 400.
+        parent_id is accepted for interface consistency
         """
         LOGGER.info("Checking access for stream: %s", self.tap_stream_id)
         config = getattr(client, 'config', {})
@@ -726,14 +754,6 @@ class VideoAds(LinkedInAds):
                 str(exc),
             )
             return False
-        except (LinkedInBadRequestError, LinkedInNotFoundError) as exc:
-            # Dummy parent ID caused a 400/404 — endpoint is reachable, credentials are fine.
-            LOGGER.info(
-                "Stream '%s': probe returned a non-403 error (%s) — endpoint reachable.",
-                self.tap_stream_id,
-                exc,
-            )
-            return True
 
     def sync_endpoint(self, *args, **kwargs):
         try:
@@ -835,6 +855,7 @@ class AdAnalyticsByCampaign(LinkedInAds):
         "timeGranularity": "DAILY",
         "count": 10000
     }
+    access_probe_extra_params = _AD_ANALYTICS_PROBE_DATE_RANGE
 
 class AdAnalyticsByCreative(LinkedInAds):
     """
@@ -855,6 +876,7 @@ class AdAnalyticsByCreative(LinkedInAds):
         "timeGranularity": "DAILY",
         "count": 10000
     }
+    access_probe_extra_params = _AD_ANALYTICS_PROBE_DATE_RANGE
 
 # Dictionary of the stream classes
 STREAMS = {

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -8,6 +8,7 @@ from singer import metrics, metadata, utils
 from singer import Transformer, should_sync_field, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
 from singer.utils import strptime_to_utc, strftime
 from tap_linkedin_ads.transform import transform_json, snake_case_to_camel_case
+from tap_linkedin_ads.client import LinkedInForbiddenError
 
 LOGGER = singer.get_logger()
 
@@ -195,6 +196,53 @@ class LinkedInAds:
     count = None
     params = {}
     headers = {}
+
+    def check_access(self, client):
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
+        This means children are never flagged by the access-check loop in _apply_access_checks();
+        their removal from the catalog is handled separately by _prune_inaccessible_children().
+        """
+        LOGGER.info("Checking access for stream: %s", self.tap_stream_id)
+        if self.parent:
+            return True
+
+        config = getattr(client, 'config', {})
+        account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
+
+        try:
+            if self.tap_stream_id in NEW_PATH_STREAMS:
+                url = "{}/adAccounts/{}/{}?q=search&pageSize=1".format(
+                    BASE_URL, account_list[0], self.path
+                )
+            else:
+                probe_params = dict(self.params)
+                probe_params['count'] = 1
+                if self.account_filter == 'search_id_values_param' and account_list:
+                    urn_list = [
+                        "urn%3Ali%3AsponsoredAccount%3A{}".format(a) for a in account_list
+                    ]
+                    probe_params['search'] = "(id:(values:List({})))".format(','.join(urn_list))
+                elif self.account_filter == 'accounts_param' and account_list:
+                    probe_params['accounts[0]'] = 'urn:li:sponsoredAccount:{}'.format(
+                        account_list[0]
+                    )
+                querystring = '&'.join(
+                    ['{}={}'.format(k, v) for k, v in probe_params.items()]
+                )
+                url = '{}/{}?{}'.format(BASE_URL, self.path, querystring)
+
+            client.get(url=url, endpoint=self.tap_stream_id, headers=self.headers)
+            return True
+        except LinkedInForbiddenError:
+            LOGGER.warning(
+                "Stream '%s' does not have read permission (403), excluding from catalog.",
+                self.__class__.__name__,
+            )
+            return False
+
     def write_schema(self, catalog):
         """
         Write the schema for the selected stream.

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -30,15 +30,21 @@ CURSOR_BASED_PAGINATION_STREAMS = ["accounts", "campaign_groups", "campaigns", "
 NEW_PATH_STREAMS = ["campaign_groups", "campaigns", "creatives"]
 BASE_URL = 'https://api.linkedin.com/rest'
 
-# adAnalytics requires dateRange — shared static 1-day probe window for both analytics streams.
-_AD_ANALYTICS_PROBE_DATE_RANGE = {
-    'dateRange.start.day': 1,
-    'dateRange.start.month': 1,
-    'dateRange.start.year': 2024,
-    'dateRange.end.day': 1,
-    'dateRange.end.month': 1,
-    'dateRange.end.year': 2024,
-}
+# adAnalytics requires dateRange — compute a rolling 5-day probe window ending today.
+def _build_ad_analytics_probe_date_range():
+    """
+    Build a 5-day date range ending today for adAnalytics access probes.
+    """
+    end = datetime.date.today()
+    start = end - timedelta(days=5)
+    return {
+        'dateRange.start.day': start.day,
+        'dateRange.start.month': start.month,
+        'dateRange.start.year': start.year,
+        'dateRange.end.day': end.day,
+        'dateRange.end.month': end.month,
+        'dateRange.end.year': end.year,
+    }
 
 def write_bookmark(state, value, stream_name):
     """
@@ -206,10 +212,13 @@ class LinkedInAds:
     count = None
     params = {}
     headers = {}
-    # Extra params merged into the access probe request only.
-    # Subclasses that require mandatory query params (e.g. dateRange for
-    # adAnalytics) can define these without overriding check_access.
-    access_probe_extra_params = {}
+
+    @property
+    def access_probe_extra_params(self):
+        # Extra params merged into the access probe request only.
+        # Subclasses that require mandatory query params (e.g. dateRange for
+        # adAnalytics) override this to return a non-empty dict.
+        return {}
 
     def _build_probe_url(self, account_list, parent_id=None):
         """
@@ -248,18 +257,15 @@ class LinkedInAds:
         account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
         if not account_list:
             return None
-        try:
-            url = self._build_probe_url(account_list)
-            data = client.get(url=url, endpoint=self.tap_stream_id, headers=dict(self.headers))
-            elements = data.get(self.data_key, [])
-            if elements:
-                raw_id = str(elements[0].get('id', ''))
-                # LinkedIn IDs may be URNs (e.g. "urn:li:sponsoredCampaign:12345");
-                # extract the numeric portion for safe URL embedding.
-                return raw_id.rsplit(':', 1)[-1] if ':' in raw_id else raw_id
-            return None
-        except Exception:  # pylint: disable=broad-except
-            return None
+        url = self._build_probe_url(account_list)
+        data = client.get(url=url, endpoint=self.tap_stream_id, headers=dict(self.headers))
+        elements = data.get(self.data_key, [])
+        if elements:
+            raw_id = str(elements[0].get('id', ''))
+            # LinkedIn IDs may be URNs (e.g. "urn:li:sponsoredCampaign:12345");
+            # extract the numeric portion for safe URL embedding.
+            return raw_id.rsplit(':', 1)[-1] if ':' in raw_id else raw_id
+        return None
 
     def check_access(self, client, parent_id=None):
         """
@@ -278,7 +284,11 @@ class LinkedInAds:
                 "Configuration error: 'accounts' must contain at least one valid account ID."
             )
 
-        # Child stream with no available parent record — skip probe with a warning.
+        # If no parent records exist, we cannot obtain a valid parent ID for the
+        # child-stream probe URL. Rather than excluding the child stream and risking
+        # a false negative, include it optimistically. Any actual access issues will
+        # be detected during sync, and users can manually deselect child streams if
+        # needed.
         if self.parent and parent_id is None:
             LOGGER.warning(
                 "Stream '%s': parent stream '%s' returned no records so no real "
@@ -855,7 +865,9 @@ class AdAnalyticsByCampaign(LinkedInAds):
         "timeGranularity": "DAILY",
         "count": 10000
     }
-    access_probe_extra_params = _AD_ANALYTICS_PROBE_DATE_RANGE
+    @property
+    def access_probe_extra_params(self):
+        return _build_ad_analytics_probe_date_range()
 
 class AdAnalyticsByCreative(LinkedInAds):
     """
@@ -876,7 +888,9 @@ class AdAnalyticsByCreative(LinkedInAds):
         "timeGranularity": "DAILY",
         "count": 10000
     }
-    access_probe_extra_params = _AD_ANALYTICS_PROBE_DATE_RANGE
+    @property
+    def access_probe_extra_params(self):
+        return _build_ad_analytics_probe_date_range()
 
 # Dictionary of the stream classes
 STREAMS = {

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -258,9 +258,9 @@ class LinkedInAds:
             return True
         except LinkedInForbiddenError as exc:
             LOGGER.warning(
-                "Permission Error: Stream '%s' %s. Excluding from catalog.",
-                self.__class__.__name__,
-                exc,
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message: '%s'",
+                self.tap_stream_id,
+                str(exc),
             )
             return False
         except (LinkedInBadRequestError, LinkedInNotFoundError) as exc:
@@ -721,9 +721,9 @@ class VideoAds(LinkedInAds):
             return True
         except LinkedInForbiddenError as exc:
             LOGGER.warning(
-                "Permission Error: Stream '%s' %s. Excluding from catalog.",
-                self.__class__.__name__,
-                exc,
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message: '%s'",
+                self.tap_stream_id,
+                str(exc),
             )
             return False
         except (LinkedInBadRequestError, LinkedInNotFoundError) as exc:

--- a/tests/base.py
+++ b/tests/base.py
@@ -34,6 +34,7 @@ class TestLinkedinAdsBase(unittest.TestCase):
     FULL_TABLE = "FULL_TABLE"
     ADDITIONAL_AUTOMATIC = "additional-automatic-fields"
     OBEYS_START_DATE = "obey-start-date"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
 
     def setUp(self):
         """Raising the error if required environment variables are missing"""
@@ -104,7 +105,8 @@ class TestLinkedinAdsBase(unittest.TestCase):
                 self.PRIMARY_KEYS: {'content_reference'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.OBEYS_START_DATE: True,
-                self.REPLICATION_KEYS: {'last_modified_time'}
+                self.REPLICATION_KEYS: {'last_modified_time'},
+                self.IS_FORBIDDEN_STREAM: True
             },
             'account_users': {
                 self.PRIMARY_KEYS: {'account_id', 'user_person_id'},
@@ -166,7 +168,11 @@ class TestLinkedinAdsBase(unittest.TestCase):
 
     def expected_streams(self):
         """A set of expected stream names"""
-        return set(self.expected_metadata().keys())
+        return {
+            stream_name
+            for stream_name, metadata in self.expected_metadata().items()
+            if not metadata.get(self.IS_FORBIDDEN_STREAM, False)
+        }
 
     def expected_start_date_keys(self):
         """
@@ -175,7 +181,8 @@ class TestLinkedinAdsBase(unittest.TestCase):
         """
         return {table: properties.get(self.REPLICATION_KEYS, set())
                 for table, properties
-                in self.expected_metadata().items()}
+                in self.expected_metadata().items()
+                if not properties.get(self.IS_FORBIDDEN_STREAM, False)}
 
     def expected_primary_keys(self):
         """
@@ -184,7 +191,8 @@ class TestLinkedinAdsBase(unittest.TestCase):
         """
         return {table: properties.get(self.PRIMARY_KEYS, set())
                 for table, properties
-                in self.expected_metadata().items()}
+                in self.expected_metadata().items()
+                if not properties.get(self.IS_FORBIDDEN_STREAM, False)}
 
     def expected_replication_keys(self):
         """
@@ -193,7 +201,8 @@ class TestLinkedinAdsBase(unittest.TestCase):
         """
         return {table: properties.get(self.REPLICATION_KEYS, set())
                 for table, properties
-                in self.expected_metadata().items()}
+                in self.expected_metadata().items()
+                if not properties.get(self.IS_FORBIDDEN_STREAM, False)}
 
     #########################
     #   Helper Methods      #

--- a/tests/test_parent_child_independent.py
+++ b/tests/test_parent_child_independent.py
@@ -4,7 +4,7 @@ from base import TestLinkedinAdsBase
 class LinkedinAdsParentChildIndependentTest(TestLinkedinAdsBase):
 
     def name(self):
-        return "tap_tester_linedin_ads_parent_child_test"
+        return "tap_tester_linkedin_ads_parent_child_test"
 
     def test_run(self):
         """
@@ -12,7 +12,7 @@ class LinkedinAdsParentChildIndependentTest(TestLinkedinAdsBase):
         • Verify that if only child streams are selected then only child streams are replicated.
         """
 
-        child_streams = {"video_ads", "creatives", "ad_analytics_by_campaign", "ad_analytics_by_creative"}
+        child_streams = {"creatives", "ad_analytics_by_campaign", "ad_analytics_by_creative"}
 
         # Instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_sync_without_refresh_token.py
+++ b/tests/test_sync_without_refresh_token.py
@@ -27,7 +27,6 @@ KNOWN_MISSING_FIELDS = {
     "accounts": {
         "total_budget_ends_at",
         "total_budget",
-        "reference_person_id",
         "notified_on_new_features_enabled",
     },
     "ad_analytics_by_creative": {

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -129,9 +129,9 @@ class TestLinkedInClient(unittest.TestCase):
         mocked_response = mock.Mock()
         mocked_response.json.return_value = {
             "expires_at": datetime.utcnow().timestamp(),
-            "created_at": (datetime.utcnow() - timedelta(days=334)).timestamp()
+            "created_at": (datetime.utcnow() - timedelta(days=335)).timestamp()
         }
-        
+
         mocked_response.status_code = 200
         mocked_post.return_value = mocked_response
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -229,17 +229,20 @@ class TestCheckAccess(unittest.TestCase):
         return STREAMS[stream_name]()
 
     def test_child_stream_always_accessible(self):
-        """Child streams (with parent) always return True from check_access."""
+        """Child streams (with parent) make a real API probe; return True on success."""
         stream = self._make_stream("video_ads")
+        self.client.get.return_value = {"elements": []}
         result = stream.check_access(self.client)
         self.assertTrue(result)
-        self.client.get.assert_not_called()
+        self.client.get.assert_called_once()
 
     def test_child_creatives_always_accessible(self):
-        """creatives (child of campaigns) always returns True."""
+        """creatives (child of campaigns) makes a real API probe; returns True on success."""
         stream = self._make_stream("creatives")
+        self.client.get.return_value = {"elements": []}
         result = stream.check_access(self.client)
         self.assertTrue(result)
+        self.client.get.assert_called_once()
 
     def test_accounts_accessible_returns_true(self):
         """check_access returns True when accounts endpoint responds successfully."""

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -306,3 +306,27 @@ class TestCheckAccess(unittest.TestCase):
         self.assertIn("987654", url)
         self.assertIn("adCampaignGroups", url)
 
+    def test_all_inaccessible_error_message(self):
+        client = mock.MagicMock()
+        client.config = {"accounts": "123456"}
+        schemas, field_metadata = get_schemas()
+        with mock.patch('tap_linkedin_ads.streams.LinkedInAds.check_access', return_value=False):
+            with self.assertRaises(LinkedInForbiddenError) as ctx:
+                _apply_access_checks(client, schemas, field_metadata)
+        self.assertIn('403', str(ctx.exception))
+        self.assertIn("do not have 'read' access to any supported streams", str(ctx.exception))
+
+    def test_all_inaccessible_exact_error_message(self):
+        """Validate the exact error message raised when no streams are accessible."""
+        client = mock.MagicMock()
+        client.config = {"accounts": "123456"}
+        schemas, field_metadata = get_schemas()
+        expected_message = (
+            "HTTP-error-code: 403, Error: The credentials "
+            "do not have 'read' access to any supported streams."
+        )
+        with mock.patch('tap_linkedin_ads.streams.LinkedInAds.check_access', return_value=False):
+            with self.assertRaises(LinkedInForbiddenError) as ctx:
+                _apply_access_checks(client, schemas, field_metadata)
+        self.assertEqual(expected_message, str(ctx.exception))
+

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -82,7 +82,7 @@ class TestApplyAccessChecks(unittest.TestCase):
         client = self._make_client()
         schemas, field_metadata = self._build_schemas_and_metadata()
 
-        def _check_access(self, client):
+        def _check_access(self, client, parent_id=None):
             if self.tap_stream_id == "accounts":
                 return False
             return True
@@ -101,7 +101,7 @@ class TestApplyAccessChecks(unittest.TestCase):
         client = self._make_client()
         schemas, field_metadata = self._build_schemas_and_metadata()
 
-        def _check_access(self, client):
+        def _check_access(self, client, parent_id=None):
             if self.tap_stream_id == "accounts":
                 return False
             return True
@@ -154,7 +154,7 @@ class TestApplyAccessChecks(unittest.TestCase):
         client = self._make_client()
         schemas, field_metadata = self._build_schemas_and_metadata()
 
-        def _check_access(self, client):
+        def _check_access(self, client, parent_id=None):
             if self.tap_stream_id == "account_users":
                 return False
             return True
@@ -237,10 +237,10 @@ class TestCheckAccess(unittest.TestCase):
         self.client.get.assert_called_once()
 
     def test_child_creatives_always_accessible(self):
-        """creatives (child of campaigns) makes a real API probe; returns True on success."""
+        """creatives (child of campaigns) makes a real API probe when a parent_id is given."""
         stream = self._make_stream("creatives")
         self.client.get.return_value = {"elements": []}
-        result = stream.check_access(self.client)
+        result = stream.check_access(self.client, parent_id="98765")
         self.assertTrue(result)
         self.client.get.assert_called_once()
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,13 +1,305 @@
 import unittest
 from unittest import mock
-from tap_linkedin_ads.discover import discover
 from singer.catalog import Catalog
+from tap_linkedin_ads.client import LinkedInForbiddenError
+from tap_linkedin_ads.discover import discover, _apply_access_checks, _prune_inaccessible_children
+from tap_linkedin_ads.schema import STREAMS, get_schemas
 
 
 class TestDiscover(unittest.TestCase):
     """Test `discover` function."""
-    def test_discover(self):
-        
-        return_catalog = discover()
-        
-        self.assertIsInstance(return_catalog, Catalog)
+
+    def _make_client(self, accounts="123456"):
+        client = mock.MagicMock()
+        client.config = {"accounts": accounts}
+        return client
+
+    def test_discover_returns_catalog(self):
+        """discover() returns a Catalog when all streams are accessible."""
+        client = self._make_client()
+        with mock.patch(
+            "tap_linkedin_ads.discover._apply_access_checks"
+        ) as mock_access:
+            mock_access.return_value = None
+            result = discover(client)
+        self.assertIsInstance(result, Catalog)
+
+    def test_discover_catalog_contains_all_streams(self):
+        """discover() catalog contains all streams when all are accessible."""
+        client = self._make_client()
+        with mock.patch(
+            "tap_linkedin_ads.discover._apply_access_checks"
+        ) as mock_access:
+            mock_access.return_value = None
+            result = discover(client)
+        stream_ids = [s.tap_stream_id for s in result.streams]
+        for stream_name in STREAMS:
+            self.assertIn(stream_name, stream_ids)
+
+    def test_discover_calls_access_checks(self):
+        """discover() calls _apply_access_checks with the client."""
+        client = self._make_client()
+        with mock.patch(
+            "tap_linkedin_ads.discover._apply_access_checks"
+        ) as mock_access:
+            mock_access.return_value = None
+            discover(client)
+        mock_access.assert_called_once()
+        call_args = mock_access.call_args[0]
+        self.assertIs(call_args[0], client)
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Test _apply_access_checks function."""
+
+    def _make_client(self, accounts="123456"):
+        client = mock.MagicMock()
+        client.config = {"accounts": accounts}
+        return client
+
+    def _build_schemas_and_metadata(self):
+        return get_schemas()
+
+    def test_all_streams_accessible_no_removal(self):
+        """No streams removed when all check_access() return True."""
+        client = self._make_client()
+        schemas, field_metadata = self._build_schemas_and_metadata()
+        original_count = len(schemas)
+
+        with mock.patch.object(
+            __import__(
+                "tap_linkedin_ads.streams", fromlist=["LinkedInAds"]
+            ).LinkedInAds,
+            "check_access",
+            return_value=True,
+        ):
+            _apply_access_checks(client, schemas, field_metadata)
+
+        self.assertEqual(len(schemas), original_count)
+
+    def test_inaccessible_parent_stream_removed(self):
+        """An inaccessible parent stream is removed from schemas."""
+        client = self._make_client()
+        schemas, field_metadata = self._build_schemas_and_metadata()
+
+        def _check_access(self, client):
+            if self.tap_stream_id == "accounts":
+                return False
+            return True
+
+        with mock.patch(
+            "tap_linkedin_ads.streams.LinkedInAds.check_access",
+            new=_check_access,
+        ):
+            _apply_access_checks(client, schemas, field_metadata)
+
+        self.assertNotIn("accounts", schemas)
+        self.assertNotIn("accounts", field_metadata)
+
+    def test_inaccessible_parent_removes_child_streams(self):
+        """Child streams are removed when their parent is inaccessible."""
+        client = self._make_client()
+        schemas, field_metadata = self._build_schemas_and_metadata()
+
+        def _check_access(self, client):
+            if self.tap_stream_id == "accounts":
+                return False
+            return True
+
+        with mock.patch(
+            "tap_linkedin_ads.streams.LinkedInAds.check_access",
+            new=_check_access,
+        ):
+            _apply_access_checks(client, schemas, field_metadata)
+
+        # video_ads is a child of accounts
+        self.assertNotIn("accounts", schemas)
+        self.assertNotIn("video_ads", schemas)
+
+    def test_inaccessible_campaigns_removes_child_streams(self):
+        """Child streams of campaigns are removed when campaigns is inaccessible."""
+        client = self._make_client()
+        schemas, field_metadata = self._build_schemas_and_metadata()
+
+        def _check_access(self, client):
+            if self.tap_stream_id == "campaigns":
+                return False
+            return True
+
+        with mock.patch(
+            "tap_linkedin_ads.streams.LinkedInAds.check_access",
+            new=_check_access,
+        ):
+            _apply_access_checks(client, schemas, field_metadata)
+
+        self.assertNotIn("campaigns", schemas)
+        self.assertNotIn("creatives", schemas)
+        self.assertNotIn("ad_analytics_by_campaign", schemas)
+        self.assertNotIn("ad_analytics_by_creative", schemas)
+
+    def test_all_parent_streams_inaccessible_raises(self):
+        """Raises LinkedInForbiddenError when ALL parent streams are inaccessible."""
+        client = self._make_client()
+        schemas, field_metadata = self._build_schemas_and_metadata()
+
+        with mock.patch(
+            "tap_linkedin_ads.streams.LinkedInAds.check_access",
+            return_value=False,
+        ):
+            with self.assertRaises(LinkedInForbiddenError):
+                _apply_access_checks(client, schemas, field_metadata)
+
+    def test_partial_inaccessibility_logs_warning(self):
+        """Warning is logged when some (but not all) parent streams are inaccessible."""
+        client = self._make_client()
+        schemas, field_metadata = self._build_schemas_and_metadata()
+
+        def _check_access(self, client):
+            if self.tap_stream_id == "account_users":
+                return False
+            return True
+
+        with mock.patch(
+            "tap_linkedin_ads.streams.LinkedInAds.check_access",
+            new=_check_access,
+        ):
+            with self.assertLogs("root", level="WARNING") as log:
+                _apply_access_checks(client, schemas, field_metadata)
+
+        self.assertTrue(
+            any("account_users" in msg for msg in log.output),
+            "Expected warning mentioning 'account_users'",
+        )
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Test _prune_inaccessible_children function."""
+
+    def _build_schemas_and_metadata(self):
+        return get_schemas()
+
+    def test_child_removed_when_parent_absent(self):
+        """video_ads is removed when accounts is not in schemas."""
+        schemas, field_metadata = self._build_schemas_and_metadata()
+        schemas.pop("accounts")
+        field_metadata.pop("accounts")
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn("video_ads", schemas)
+        self.assertNotIn("video_ads", field_metadata)
+
+    def test_child_kept_when_parent_present(self):
+        """video_ads is kept when accounts is present in schemas."""
+        schemas, field_metadata = self._build_schemas_and_metadata()
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertIn("video_ads", schemas)
+
+    def test_campaigns_children_removed_when_campaigns_absent(self):
+        """creatives, ad_analytics_by_campaign, ad_analytics_by_creative removed when campaigns absent."""
+        schemas, field_metadata = self._build_schemas_and_metadata()
+        schemas.pop("campaigns")
+        field_metadata.pop("campaigns")
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn("creatives", schemas)
+        self.assertNotIn("ad_analytics_by_campaign", schemas)
+        self.assertNotIn("ad_analytics_by_creative", schemas)
+
+    def test_no_removal_when_all_parents_present(self):
+        """No streams removed when all parent streams are present."""
+        schemas, field_metadata = self._build_schemas_and_metadata()
+        original_count = len(schemas)
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertEqual(len(schemas), original_count)
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Test LinkedInAds.check_access() method."""
+
+    def _make_stream(self, stream_name, accounts="123456"):
+        from tap_linkedin_ads.streams import STREAMS
+        self.client = mock.MagicMock()
+        self.client.config = {"accounts": accounts}
+        return STREAMS[stream_name]()
+
+    def test_child_stream_always_accessible(self):
+        """Child streams (with parent) always return True from check_access."""
+        stream = self._make_stream("video_ads")
+        result = stream.check_access(self.client)
+        self.assertTrue(result)
+        self.client.get.assert_not_called()
+
+    def test_child_creatives_always_accessible(self):
+        """creatives (child of campaigns) always returns True."""
+        stream = self._make_stream("creatives")
+        result = stream.check_access(self.client)
+        self.assertTrue(result)
+
+    def test_accounts_accessible_returns_true(self):
+        """check_access returns True when accounts endpoint responds successfully."""
+        stream = self._make_stream("accounts")
+        self.client.get.return_value = {"elements": []}
+        result = stream.check_access(self.client)
+        self.assertTrue(result)
+        self.client.get.assert_called_once()
+
+    def test_accounts_forbidden_returns_false(self):
+        """check_access returns False when accounts endpoint returns 403."""
+        stream = self._make_stream("accounts")
+        self.client.get.side_effect = LinkedInForbiddenError("403")
+        result = stream.check_access(self.client)
+        self.assertFalse(result)
+
+    def test_account_users_accessible_returns_true(self):
+        """check_access returns True when account_users endpoint responds successfully."""
+        stream = self._make_stream("account_users")
+        self.client.get.return_value = {"elements": []}
+        result = stream.check_access(self.client)
+        self.assertTrue(result)
+
+    def test_account_users_forbidden_returns_false(self):
+        """check_access returns False when account_users returns 403."""
+        stream = self._make_stream("account_users")
+        self.client.get.side_effect = LinkedInForbiddenError("403")
+        result = stream.check_access(self.client)
+        self.assertFalse(result)
+
+    def test_campaign_groups_accessible_returns_true(self):
+        """check_access returns True when campaign_groups endpoint responds successfully."""
+        stream = self._make_stream("campaign_groups")
+        self.client.get.return_value = {"elements": []}
+        result = stream.check_access(self.client)
+        self.assertTrue(result)
+
+    def test_campaigns_accessible_returns_true(self):
+        """check_access returns True when campaigns endpoint responds successfully."""
+        stream = self._make_stream("campaigns")
+        self.client.get.return_value = {"elements": []}
+        result = stream.check_access(self.client)
+        self.assertTrue(result)
+
+    def test_check_access_uses_correct_url_for_accounts(self):
+        """check_access passes an adAccounts URL for the accounts stream."""
+        stream = self._make_stream("accounts")
+        self.client.get.return_value = {}
+        stream.check_access(self.client)
+        call_kwargs = self.client.get.call_args
+        url = call_kwargs[1].get("url") or call_kwargs[0][0]
+        self.assertIn("adAccounts", url)
+
+    def test_check_access_uses_account_id_in_url_for_campaign_groups(self):
+        """check_access includes account ID in URL for campaign_groups."""
+        stream = self._make_stream("campaign_groups", accounts="987654")
+        self.client.get.return_value = {}
+        stream.check_access(self.client)
+        call_kwargs = self.client.get.call_args
+        url = call_kwargs[1].get("url") or call_kwargs[0][0]
+        self.assertIn("987654", url)
+        self.assertIn("adCampaignGroups", url)
+


### PR DESCRIPTION
# Description of change

- 403-inaccessible streams are excluded from the catalog during discovery instead of raising an error
- Child streams are pruned when their parent is inaccessible
- Raises LinkedInForbiddenError only if all streams are inaccessible
- `accounts` added to `REQUIRED_CONFIG_KEYS` — fails fast at startup if missing
- Updated unit tests
- [SAC-30941](https://qlik-dev.atlassian.net/browse/SAC-30941)

# Manual QA steps
- [x] Discovery: Running
- [x] Sync: Running
- [x] Unit tests: Running
- [x] Integration Tests: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
