### PR TITLE
fix: raise error on inaccessible accounts and gracefully handle 404 during discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.0
+  * Raise error on inaccessible accounts [#88](https://github.com/singer-io/tap-linkedin-ads/pull/88)
+  * Accept URN based account IDs
+
 ## 2.7.0
   * Exclude 403-inaccessible streams from catalog during discovery [#86](https://github.com/singer-io/tap-linkedin-ads/pull/86)
   * Added `accounts` as a required config field

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='2.7.0',
+      version='2.8.0',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_linkedin_ads/__init__.py
+++ b/tap_linkedin_ads/__init__.py
@@ -22,7 +22,6 @@ REQUIRED_CONFIG_KEYS = [
 
 def do_discover(client, config):
     LOGGER.info('Starting discover')
-    client.check_accounts(config)
     client.config = config
     catalog = _discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
@@ -46,6 +45,9 @@ def main():
         state = {}
         if parsed_args.state:
             state = parsed_args.state
+
+        client.check_accounts(config)
+
         if parsed_args.discover:
             do_discover(client, config)
         elif parsed_args.catalog:

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -304,6 +304,11 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
 
         if config.get('accounts'):
             account_list = config['accounts'].replace(" ", "").split(",")
+            # Normalize to numeric IDs — accept both '12345' and 'urn:li:sponsoredAccount:12345'
+            account_list = [
+                a.rsplit(':', 1)[-1] if ':' in a else a
+                for a in account_list if a
+            ]
             invalid_account = []
             for account in account_list:
                 response = self.__session.get(

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -295,13 +295,6 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
                           max_tries=5,
                           factor=2)
     def check_accounts(self, config):
-        headers = {}
-        if self.__user_agent:
-            headers['User-Agent'] = self.__user_agent
-        headers['Authorization'] = 'Bearer {}'.format(self.__access_token)
-        headers['Accept'] = 'application/json'
-        headers['LinkedIn-Version'] = LINKEDIN_VERSION
-
         if config.get('accounts'):
             account_list = config['accounts'].replace(" ", "").split(",")
             # Normalize to numeric IDs — accept both '12345' and 'urn:li:sponsoredAccount:12345'
@@ -309,19 +302,26 @@ class LinkedinClient: # pylint: disable=too-many-instance-attributes
                 a.rsplit(':', 1)[-1] if ':' in a else a
                 for a in account_list if a
             ]
-            invalid_account = []
-            for account in account_list:
-                response = self.__session.get(
-                    url='https://api.linkedin.com/rest/adAccountUsers?q=accounts&count=1&start=0&accounts=urn:li:sponsoredAccount:{}'.format(account),
-                    headers=headers,
-                    timeout=self.request_timeout)
+            if not account_list:
+                return
 
-                # Account users API will return 400 if account is not in number format.
-                # Account users API will return 404 if provided account is valid number but invalid LinkedIn Ads account
-                if response.status_code in [400, 404]:
-                    invalid_account.append(account)
-                elif response.status_code != 200:
-                    raise_for_error(response)
+            urn_list = ["urn%3Ali%3AsponsoredAccount%3A{}".format(a) for a in account_list]
+            search_param = "(id:(values:List({})))".format(','.join(urn_list))
+            accounts_check_url = 'https://api.linkedin.com/rest/adAccounts?pageSize={}&q=search&search={}'.format(
+                len(account_list), search_param
+            )
+            response = self.get(
+                url=accounts_check_url,
+                endpoint='accounts',
+                headers={'X-Restli-Protocol-Version': '2.0.0'}
+            )
+            # LinkedIn may return element IDs as URNs (e.g. "urn:li:sponsoredAccount:12345");
+            # extract the trailing numeric portion so comparison works regardless of format.
+            visible_ids = {
+                str(e.get('id')).rsplit(':', 1)[-1]
+                for e in response.get('elements', [])
+            }
+            invalid_account = [a for a in account_list if a not in visible_ids]
             if invalid_account:
                 error_message = 'Invalid Linked Ads accounts provided during the configuration:{}'.format(invalid_account)
                 raise Exception(error_message) from None

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -8,7 +8,7 @@ from singer import metrics, metadata, utils
 from singer import Transformer, should_sync_field, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
 from singer.utils import strptime_to_utc, strftime
 from tap_linkedin_ads.transform import transform_json, snake_case_to_camel_case
-from tap_linkedin_ads.client import LinkedInForbiddenError
+from tap_linkedin_ads.client import LinkedInForbiddenError, LinkedInNotFoundError
 
 LOGGER = singer.get_logger()
 
@@ -757,7 +757,7 @@ class VideoAds(LinkedInAds):
         try:
             client.get(url=url, endpoint=self.tap_stream_id, headers=dict(self.headers))
             return True
-        except LinkedInForbiddenError as exc:
+        except (LinkedInForbiddenError, LinkedInNotFoundError) as exc:
             LOGGER.warning(
                 "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message: '%s'",
                 self.tap_stream_id,

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -254,7 +254,10 @@ class LinkedInAds:
         Used so child streams can be probed with a real parent ID at discovery time.
         """
         config = getattr(client, 'config', {})
-        account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
+        account_list = [
+            a.strip().rsplit(':', 1)[-1] if ':' in a.strip() else a.strip()
+            for a in config.get('accounts', '').split(',') if a.strip()
+        ]
         if not account_list:
             return None
         url = self._build_probe_url(account_list)
@@ -277,7 +280,10 @@ class LinkedInAds:
         """
         LOGGER.info("Checking access for stream: %s", self.tap_stream_id)
         config = getattr(client, 'config', {})
-        account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
+        account_list = [
+            a.strip().rsplit(':', 1)[-1] if ':' in a.strip() else a.strip()
+            for a in config.get('accounts', '').split(',') if a.strip()
+        ]
 
         if not account_list:
             raise ValueError(
@@ -744,7 +750,10 @@ class VideoAds(LinkedInAds):
         """
         LOGGER.info("Checking access for stream: %s", self.tap_stream_id)
         config = getattr(client, 'config', {})
-        account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
+        account_list = [
+            a.strip().rsplit(':', 1)[-1] if ':' in a.strip() else a.strip()
+            for a in config.get('accounts', '').split(',') if a.strip()
+        ]
 
         if not account_list:
             raise ValueError(

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -302,7 +302,7 @@ class LinkedInAds:
             url = self._build_probe_url(account_list, parent_id=parent_id)
             client.get(url=url, endpoint=self.tap_stream_id, headers=dict(self.headers))
             return True
-        except LinkedInForbiddenError as exc:
+        except (LinkedInForbiddenError, LinkedInNotFoundError) as exc:
             LOGGER.warning(
                 "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message: '%s'",
                 self.tap_stream_id, str(exc),

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -85,28 +85,28 @@ def sync(client, config, catalog, state):
     # (e.g. adAccounts/{id}/adCampaigns) when the token's user is not a member of the
     # account, making it impossible to distinguish "no data" from "no access" at the
     # stream level. This check surfaces the problem early and clearly.
-    configured_accounts = config['accounts'].replace(" ", "").split(",")
-    configured_accounts = [a for a in configured_accounts if a]
-    urn_list = ["urn%3Ali%3AsponsoredAccount%3A{}".format(a) for a in configured_accounts]
+    account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
+    if not account_list:
+        raise ValueError(
+            "Configuration error: 'accounts' must contain at least one valid account ID."
+        )
+    urn_list = ["urn%3Ali%3AsponsoredAccount%3A{}".format(a) for a in account_list]
     search_param = "(id:(values:List({})))".format(','.join(urn_list))
     accounts_check_url = 'https://api.linkedin.com/rest/adAccounts?pageSize={}&q=search&search={}'.format(
-        len(configured_accounts), search_param
+        len(account_list), search_param
     )
-    try:
-        visible = client.get(
-            url=accounts_check_url,
-            endpoint='accounts',
-            headers={'X-Restli-Protocol-Version': '2.0.0'}
+    visible = client.get(
+        url=accounts_check_url,
+        endpoint='accounts',
+        headers={'X-Restli-Protocol-Version': '2.0.0'}
+    )
+    visible_ids = {str(e.get('id')) for e in visible.get('elements', [])}
+    inaccessible = [a for a in account_list if a not in visible_ids]
+    if inaccessible:
+        raise Exception(
+            "Account(s) not found or inaccessible: {}. "
+            "Please verify the account ID(s) in your configuration.".format(', '.join(inaccessible))
         )
-        visible_ids = {str(e.get('id')) for e in visible.get('elements', [])}
-        inaccessible = [a for a in configured_accounts if a not in visible_ids]
-        if inaccessible:
-            raise Exception(
-                "Account(s) not found or inaccessible: {}. "
-                "Please verify the account ID(s) in your configuration.".format(', '.join(inaccessible))
-            )
-    except Exception:
-        raise
 
     # Get ALL selected streams from catalog
     selected_streams = []
@@ -132,7 +132,6 @@ def sync(client, config, catalog, state):
         # Add appropriate account_filter query parameters based on account_filter type
         account_filter = stream_obj.account_filter
         if config.get("accounts") and account_filter is not None:
-            account_list = config['accounts'].replace(" ", "").split(",")
             if len(account_list) > 0:
                 params = stream_obj.params
                 if account_filter == 'search_id_values_param':

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -85,7 +85,12 @@ def sync(client, config, catalog, state):
     # (e.g. adAccounts/{id}/adCampaigns) when the token's user is not a member of the
     # account, making it impossible to distinguish "no data" from "no access" at the
     # stream level. This check surfaces the problem early and clearly.
-    account_list = [a.strip() for a in config.get('accounts', '').split(',') if a.strip()]
+    # Normalize account IDs to plain numeric form, accepting both '12345' and
+    # 'urn:li:sponsoredAccount:12345' as valid input formats.
+    account_list = [
+        a.strip().rsplit(':', 1)[-1] if ':' in a.strip() else a.strip()
+        for a in config.get('accounts', '').split(',') if a.strip()
+    ]
     if not account_list:
         raise ValueError(
             "Configuration error: 'accounts' must contain at least one valid account ID."
@@ -100,10 +105,15 @@ def sync(client, config, catalog, state):
         endpoint='accounts',
         headers={'X-Restli-Protocol-Version': '2.0.0'}
     )
-    visible_ids = {str(e.get('id')) for e in visible.get('elements', [])}
+    # LinkedIn may return element IDs as URNs (e.g. "urn:li:sponsoredAccount:12345");
+    # extract the trailing numeric portion so comparison works regardless of format.
+    visible_ids = {
+        str(e.get('id')).rsplit(':', 1)[-1]
+        for e in visible.get('elements', [])
+    }
     inaccessible = [a for a in account_list if a not in visible_ids]
     if inaccessible:
-        raise Exception(
+        raise PermissionError(
             "Account(s) not found or inaccessible: {}. "
             "Please verify the account ID(s) in your configuration.".format(', '.join(inaccessible))
         )

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -80,6 +80,34 @@ def sync(client, config, catalog, state):
         date_window_size = DATE_WINDOW_SIZE
         LOGGER.info('Using standard date window size of %s', DATE_WINDOW_SIZE)
 
+    # Validate that the token has access to the configured accounts before syncing.
+    # The LinkedIn API silently returns 200 with empty results for path-based endpoints
+    # (e.g. adAccounts/{id}/adCampaigns) when the token's user is not a member of the
+    # account, making it impossible to distinguish "no data" from "no access" at the
+    # stream level. This check surfaces the problem early and clearly.
+    configured_accounts = config['accounts'].replace(" ", "").split(",")
+    configured_accounts = [a for a in configured_accounts if a]
+    urn_list = ["urn%3Ali%3AsponsoredAccount%3A{}".format(a) for a in configured_accounts]
+    search_param = "(id:(values:List({})))".format(','.join(urn_list))
+    accounts_check_url = 'https://api.linkedin.com/rest/adAccounts?pageSize={}&q=search&search={}'.format(
+        len(configured_accounts), search_param
+    )
+    try:
+        visible = client.get(
+            url=accounts_check_url,
+            endpoint='accounts',
+            headers={'X-Restli-Protocol-Version': '2.0.0'}
+        )
+        visible_ids = {str(e.get('id')) for e in visible.get('elements', [])}
+        inaccessible = [a for a in configured_accounts if a not in visible_ids]
+        if inaccessible:
+            raise Exception(
+                "Account(s) not found or inaccessible: {}. "
+                "Please verify the account ID(s) in your configuration.".format(', '.join(inaccessible))
+            )
+    except Exception:
+        raise
+
     # Get ALL selected streams from catalog
     selected_streams = []
     for stream in catalog.get_selected_streams(state):

--- a/tap_linkedin_ads/sync.py
+++ b/tap_linkedin_ads/sync.py
@@ -80,43 +80,12 @@ def sync(client, config, catalog, state):
         date_window_size = DATE_WINDOW_SIZE
         LOGGER.info('Using standard date window size of %s', DATE_WINDOW_SIZE)
 
-    # Validate that the token has access to the configured accounts before syncing.
-    # The LinkedIn API silently returns 200 with empty results for path-based endpoints
-    # (e.g. adAccounts/{id}/adCampaigns) when the token's user is not a member of the
-    # account, making it impossible to distinguish "no data" from "no access" at the
-    # stream level. This check surfaces the problem early and clearly.
     # Normalize account IDs to plain numeric form, accepting both '12345' and
     # 'urn:li:sponsoredAccount:12345' as valid input formats.
     account_list = [
         a.strip().rsplit(':', 1)[-1] if ':' in a.strip() else a.strip()
         for a in config.get('accounts', '').split(',') if a.strip()
     ]
-    if not account_list:
-        raise ValueError(
-            "Configuration error: 'accounts' must contain at least one valid account ID."
-        )
-    urn_list = ["urn%3Ali%3AsponsoredAccount%3A{}".format(a) for a in account_list]
-    search_param = "(id:(values:List({})))".format(','.join(urn_list))
-    accounts_check_url = 'https://api.linkedin.com/rest/adAccounts?pageSize={}&q=search&search={}'.format(
-        len(account_list), search_param
-    )
-    visible = client.get(
-        url=accounts_check_url,
-        endpoint='accounts',
-        headers={'X-Restli-Protocol-Version': '2.0.0'}
-    )
-    # LinkedIn may return element IDs as URNs (e.g. "urn:li:sponsoredAccount:12345");
-    # extract the trailing numeric portion so comparison works regardless of format.
-    visible_ids = {
-        str(e.get('id')).rsplit(':', 1)[-1]
-        for e in visible.get('elements', [])
-    }
-    inaccessible = [a for a in account_list if a not in visible_ids]
-    if inaccessible:
-        raise PermissionError(
-            "Account(s) not found or inaccessible: {}. "
-            "Please verify the account ID(s) in your configuration.".format(', '.join(inaccessible))
-        )
 
     # Get ALL selected streams from catalog
     selected_streams = []

--- a/tests/base.py
+++ b/tests/base.py
@@ -105,8 +105,7 @@ class TestLinkedinAdsBase(unittest.TestCase):
                 self.PRIMARY_KEYS: {'content_reference'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.OBEYS_START_DATE: True,
-                self.REPLICATION_KEYS: {'last_modified_time'},
-                self.IS_FORBIDDEN_STREAM: True
+                self.REPLICATION_KEYS: {'last_modified_time'}
             },
             'account_users': {
                 self.PRIMARY_KEYS: {'account_id', 'user_person_id'},

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -68,41 +68,38 @@ class TestBackoffHandling(unittest.TestCase):
         (503 , "", client.Server5xxError),
     ])
     @mock.patch("time.sleep")
-    @mock.patch("requests.Session.get")
-    def test_check_accounts_backoff(self, error_code, message, error, mock_requests, mock_sleep):
+    @mock.patch("tap_linkedin_ads.client.LinkedinClient.get")
+    def test_check_accounts_backoff(self, error_code, message, error, mock_get, mock_sleep):
         """
         Test `check_accounts` will backoff 5 times for 5xx error.
         """
         config = {"accounts": "acc1"}
-        json_resp = {"message": message,
-                    "status": error_code,
-                    "code": ""}
-        mock_requests.return_value = get_response(error_code, json_resp)
+        mock_get.side_effect = error
         linkedIn_client = client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'config_path', 'access_token')
         with self.assertRaises(error) as e:
             linkedIn_client.check_accounts(config)
 
-        # Verify that `session.get` was called 5 times
-        self.assertEqual(mock_requests.call_count, 5)
+        # Verify that `client.get` was called 5 times
+        self.assertEqual(mock_get.call_count, 5)
 
     @parameterized.expand([
         (requests.exceptions.Timeout, requests.exceptions.Timeout),
         (requests.exceptions.ConnectionError, requests.exceptions.ConnectionError),
     ])
     @mock.patch("time.sleep")
-    @mock.patch("requests.Session.get")
-    def test_check_accounts_backoff_2(self, mock_response, error, mock_requests, mock_sleep):
+    @mock.patch("tap_linkedin_ads.client.LinkedinClient.get")
+    def test_check_accounts_backoff_2(self, mock_response, error, mock_get, mock_sleep):
         """
         Test `check_accounts` will backoff 5 times for Timeout and ConnectionError.
         """
         config = {"accounts": "acc1"}
-        mock_requests.side_effect = mock_response
+        mock_get.side_effect = mock_response
         linkedIn_client = client.LinkedinClient('client_id', 'client_secret', 'refresh_token', 'config_path', 'access_token')
         with self.assertRaises(error) as e:
             linkedIn_client.check_accounts(config)
 
-        # Verify that `session.get` was called 5 times
-        self.assertEqual(mock_requests.call_count, 5)
+        # Verify that `client.get` was called 5 times
+        self.assertEqual(mock_get.call_count, 5)
 
     @mock.patch("time.sleep")
     @mock.patch("requests.Session.request")
@@ -274,28 +271,24 @@ class TestAccessToken(unittest.TestCase):
         # Verify that the exception message was expected
         self.assertEqual(str(e.exception), "HTTP-error-code: 401, Error: {}".format(response_json.get('message')))
 
-@mock.patch("requests.Session.get")
+@mock.patch("tap_linkedin_ads.client.LinkedinClient.get")
 class TestCheckAccounts(unittest.TestCase):
     """
     Test exception handling for `check_accounts` method of client.
     """
     _client = client.LinkedinClient("","","", "","", "", "USR_AGENT")
 
-    @parameterized.expand([
-        (400,),
-        (404,),
-    ])
-    def test_invalid_accouts(self, mock_get, error_code):
+    def test_invalid_accouts(self, mock_get):
         """
-        Test for 400, 404 errors custom error message is written.
+        Test that accounts not returned by the adAccounts search API are flagged as invalid.
         """
         config = {"accounts": "account1,account2"}
         error_message = "Invalid Linked Ads accounts provided during the configuration:{}".format(["account1","account2"])
-        mock_get.return_value = get_response(error_code)
+        mock_get.return_value = {"elements": []}
 
         with self.assertRaises(Exception) as e:
             self._client.check_accounts(config)
 
         # Verify that error message is expected
         self.assertEqual(str(e.exception), error_message)
-        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(mock_get.call_count, 1)

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -153,7 +153,7 @@ class TestSync(unittest.TestCase):
         """
         Test sync function
         """
-        mock_client_get.return_value = {'elements': [{'id': int(config['accounts'])}]}
+        mock_client_get.return_value = {'elements': [{'id': 'urn:li:sponsoredAccount:{}'.format(config['accounts'])}]}
         client = LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
         state = {} 
 

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -148,10 +148,12 @@ class TestSync(unittest.TestCase):
         ['test_sync_with_datewindow', {'start_date': '2019-06-01T00:00:00Z', 'date_window_size': 7, 'accounts': '1245'}, 7]
     ])
     @mock.patch('tap_linkedin_ads.streams.LinkedInAds.sync_endpoint', return_value=(1, '2020-06-01T00:00:00Z'))
-    def test_sync(self, name, config, expected_date_window, mock_sync_endpoint):
+    @mock.patch('tap_linkedin_ads.client.LinkedinClient.get')
+    def test_sync(self, name, config, expected_date_window, mock_client_get, mock_sync_endpoint):
         """
         Test sync function
         """
+        mock_client_get.return_value = {'elements': [{'id': int(config['accounts'])}]}
         client = LinkedinClient('client_id', 'client_secret', 'refresh_token', 'access_token', 'config_path')
         state = {} 
 

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -113,20 +113,21 @@ class TestTimeoutBackoff(unittest.TestCase):
         # verify that we backoff for 5 times
         self.assertEqual(mocked_request.call_count, 5)
 
-    def test_timeout_error__check_accounts(self, mocked_request, mocked_sleep):
+    @mock.patch("tap_linkedin_ads.client.LinkedinClient.get")
+    def test_timeout_error__check_accounts(self, mock_get, mocked_request, mocked_sleep):
         """
         Test `check_accounts` will backoff 5 times on Timeout. 
         """
 
-        # mock request and raise the 'Timeout' error
-        mocked_request.side_effect = requests.Timeout
+        # mock client.get to raise Timeout directly, avoiding nested backoff in request()
+        mock_get.side_effect = requests.Timeout
 
         with self.assertRaises(requests.Timeout):
             # function call
             self.client.check_accounts(self.config)
 
         # verify that we backoff for 5 times
-        self.assertEqual(mocked_request.call_count, 5)
+        self.assertEqual(mock_get.call_count, 5)
 
     def test_timeout_error__request(self, mocked_request, mocked_sleep):
         """
@@ -180,13 +181,14 @@ class TestConnectionErrorBackoff(unittest.TestCase):
         # verify that we backoff for 5 times
         self.assertEqual(mocked_request.call_count, 5)
 
-    def test_connection_error__check_accounts(self, mocked_request, mocked_sleep):
+    @mock.patch("tap_linkedin_ads.client.LinkedinClient.get")
+    def test_connection_error__check_accounts(self, mock_get, mocked_request, mocked_sleep):
         """
         Test for `check_accounts` will backoff 5 times on ConnectionError.
         """
 
-        # mock request and raise the 'ConnectionError'
-        mocked_request.side_effect = requests.ConnectionError
+        # mock client.get to raise ConnectionError directly, avoiding nested backoff in request()
+        mock_get.side_effect = requests.ConnectionError
 
         config = {"client_id": "test_client_id",
                   "client_secret": "test_client_secret",
@@ -209,4 +211,4 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             cl.check_accounts(config)
 
         # verify that we backoff for 5 times
-        self.assertEqual(mocked_request.call_count, 5)
+        self.assertEqual(mock_get.call_count, 5)


### PR DESCRIPTION
JIRA - https://qlik-dev.atlassian.net/browse/SUPPORT-10913
## Problem

Two separate issues were found while testing the tap:

**1. Silent zero-record sync for inaccessible accounts**
When the token's LinkedIn user is not a member of the configured ad account, LinkedIn's path-based endpoints return `200 OK` with an empty `elements` array instead of `403 Forbidden`. This made it impossible to distinguish "no data" from "no access" — the tap would complete successfully with 0 records and no indication of the real problem.

**2. Discovery crash on 404 responses during stream access checks**
`check_access` only caught `LinkedInForbiddenError` (403). LinkedIn can also return `404 NOT_FOUND` for streams where the account lacks the required API product access. This uncaught exception crashed the entire discovery process, blocking all other streams from being catalogued.

## Fix

**client.py**: (which silently returned 200 for invalid accounts) with a single batch call to the adAccounts search endpoint. Accounts not present in the response are raised as invalid.
**__init__.py** : Moved [check_accounts] call from do_discover to main, so account validation runs once before both discover and sync.

# Manual QA steps
 - Passed invalid account ID and verified the exception log.
 - Performed the PR-alpha on the customer connection.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
